### PR TITLE
Replace qt4-automoc with qt4_wrap_cpp

### DIFF
--- a/libavogadro/src/CMakeLists.txt
+++ b/libavogadro/src/CMakeLists.txt
@@ -75,6 +75,42 @@ set(libavogadro_HDRS
   zmatrix.h
 )
 
+SET(libavogadro_MOC_HDRS
+  animation.h
+  atom.h
+  bond.h
+  color.h
+  colorbutton.h
+  colors/elementcolor.h
+  cube.h
+  elementdetail_p.h
+  elementtranslator.h
+  engine.h
+  engines/bsdyengine.h
+  extension.h
+  fragment.h
+  glwidget.h
+  mesh.h
+  molecule.h
+  moleculefile.h
+  moleculefile_p.h
+  periodictablescene_p.h
+  periodictableview.h
+  plotwidget.h
+  plugin.h
+  pluginmanager.h
+  primitive.h
+  protein.h
+  pythonengine_p.h
+  pythonerror.h
+  pythonextension_p.h
+  pythontool_p.h
+  residue.h
+  tool.h
+  toolgroup.h
+  zmatrix.h
+)
+
 set(libavogadro_SRCS ${libavogadro_SRCS} ${libavogadro_UIS})
 # Also add in the qtiocompressor class
 #set(libavogadro_SRCS ${libavogadro_SRCS} ../qtiocompressor/qtiocompressor.cpp)
@@ -113,7 +149,7 @@ if(NOT ENABLE_PYTHON OR NOT ALL_PYTHON_FOUND)
   endforeach(P_ITEM ${PYTHON_SRCS})
 endif(NOT ENABLE_PYTHON OR NOT ALL_PYTHON_FOUND)
 
-qt4_automoc(${libavogadro_SRCS})
+QT4_WRAP_CPP(libavogadro_MOC_SRCS ${libavogadro_MOC_HDRS})
 
 # you have to add link_directories before you add the target
 if(ENABLE_PYTHON AND ALL_PYTHON_FOUND)
@@ -149,7 +185,7 @@ foreach(headerFile ${libavogadro_HDRS})
     COMMAND ${CMAKE_COMMAND} -E ${header_cmd} "${from}" "${to}")
 endforeach(headerFile ${libavogadro_HDRS})
 
-add_library(avogadro SHARED ${libavogadro_SRCS} ${libavogadro_QM} ${pythontool_RC_SRCS})
+add_library(avogadro SHARED ${libavogadro_SRCS} ${libavogadro_MOC_SRCS} ${libavogadro_QM} ${pythontool_RC_SRCS})
 set_target_properties(avogadro
   PROPERTIES VERSION ${Avogadro_VERSION_FULL} SOVERSION 1 )
 target_link_libraries(avogadro ${AVO_LINK_LIBRARIES})

--- a/libavogadro/src/animation.cpp
+++ b/libavogadro/src/animation.cpp
@@ -224,5 +224,3 @@ namespace Avogadro {
   }
 
 } // end namespace Avogadro
-
-#include "animation.moc"

--- a/libavogadro/src/atom.cpp
+++ b/libavogadro/src/atom.cpp
@@ -293,5 +293,3 @@ using Eigen::Vector3d;
    }
 
  } // End namespace Avogadro
-
-#include "atom.moc"

--- a/libavogadro/src/bond.cpp
+++ b/libavogadro/src/bond.cpp
@@ -166,5 +166,3 @@
   }
 
 } // End namespace Avogadro
-
-#include "bond.moc"

--- a/libavogadro/src/color.cpp
+++ b/libavogadro/src/color.cpp
@@ -152,5 +152,3 @@ namespace Avogadro {
     return "Generic Color";
   }
 }
-
-#include "color.moc"

--- a/libavogadro/src/colorbutton.cpp
+++ b/libavogadro/src/colorbutton.cpp
@@ -94,5 +94,3 @@ namespace Avogadro {
   }
 
 } // end namespace
-
-#include "colorbutton.moc"

--- a/libavogadro/src/colors/elementcolor.cpp
+++ b/libavogadro/src/colors/elementcolor.cpp
@@ -63,7 +63,5 @@ namespace Avogadro {
 
 }
 
-#include "elementcolor.moc"
 //this is a static color plugin...
 //Q_EXPORT_PLUGIN2(elementcolor, Avogadro::ElementColorFactory)
-

--- a/libavogadro/src/cube.cpp
+++ b/libavogadro/src/cube.cpp
@@ -322,5 +322,3 @@ namespace Avogadro {
   }
 
 } // End namespace Avogadro
-
-#include "cube.moc"

--- a/libavogadro/src/elementdetail_p.cpp
+++ b/libavogadro/src/elementdetail_p.cpp
@@ -132,5 +132,3 @@ namespace Avogadro{
   }
 
 } // End namespace Avogadro
-
-#include "elementdetail_p.moc"

--- a/libavogadro/src/elementtranslator.cpp
+++ b/libavogadro/src/elementtranslator.cpp
@@ -401,5 +401,3 @@ namespace Avogadro {
   }
 
 } // End namespace Avogadro
-
-#include "elementtranslator.moc"

--- a/libavogadro/src/engine.cpp
+++ b/libavogadro/src/engine.cpp
@@ -377,5 +377,3 @@ namespace Avogadro {
       return m_molecule->bonds();
   }
 }
-
-#include "engine.moc"

--- a/libavogadro/src/engines/bsdyengine.cpp
+++ b/libavogadro/src/engines/bsdyengine.cpp
@@ -442,7 +442,5 @@ namespace Avogadro
   }
 
 }
-
-#include "bsdyengine.moc"
 // This is a static engine...
 // Q_EXPORT_PLUGIN2( bsdyengine, Avogadro::BSDYEngineFactory )

--- a/libavogadro/src/extension.cpp
+++ b/libavogadro/src/extension.cpp
@@ -80,5 +80,3 @@ namespace Avogadro {
   }
 
 }
-
-#include "extension.moc"

--- a/libavogadro/src/fragment.cpp
+++ b/libavogadro/src/fragment.cpp
@@ -82,5 +82,3 @@ namespace Avogadro {
   }
 
 } // End namespace Avogadro
-
-#include "fragment.moc"

--- a/libavogadro/src/glwidget.cpp
+++ b/libavogadro/src/glwidget.cpp
@@ -1966,5 +1966,3 @@ namespace Avogadro {
     d->updateCache = true;
   }
 }
-
-#include "glwidget.moc"

--- a/libavogadro/src/mesh.cpp
+++ b/libavogadro/src/mesh.cpp
@@ -231,5 +231,3 @@ namespace Avogadro {
   }
 
 } // End namespace Avogadro
-
-#include "mesh.moc"

--- a/libavogadro/src/molecule.cpp
+++ b/libavogadro/src/molecule.cpp
@@ -1575,5 +1575,3 @@ namespace Avogadro{
   }
 
 } // End namespace Avogadro
-
-#include "molecule.moc"

--- a/libavogadro/src/moleculefile.cpp
+++ b/libavogadro/src/moleculefile.cpp
@@ -22,22 +22,13 @@
   02110-1301, USA.
  **********************************************************************/
 
-#include "moleculefile.h"
+#include "moleculefile_p.h"
 
 #include <avogadro/molecule.h>
 
-#include <QFile>
 #include <QFileInfo>
-#include <QStringList>
-#include <QThread>
 #include <QDebug>
 #include <QPointer>
-
-#include <openbabel/mol.h>
-#include <openbabel/obconversion.h>
-
-// Included in obconversion.h
-//#include <iostream>
 
 namespace Avogadro {
 
@@ -578,164 +569,6 @@ namespace Avogadro {
     return false;
   }
 
-  class ReadFileThread : public QThread
-  {
-    //    Q_OBJECT 
-
-    public:
-      ReadFileThread(MoleculeFile *moleculeFile) : m_moleculeFile(moleculeFile)
-      {
-      }
-      
-      void addConformer(const OpenBabel::OBMol &conformer)
-      {
-        unsigned int numAtoms = conformer.NumAtoms();
-        std::vector<Eigen::Vector3d> *coords = new std::vector<Eigen::Vector3d>(numAtoms);
-        for (unsigned int i = 0; i < numAtoms; ++i)
-          coords->push_back(Eigen::Vector3d(conformer.GetAtom(i+1)->GetVector().AsArray()));
-        m_moleculeFile->m_conformers.push_back(coords);
-      }
-
-      void detectConformers(unsigned int c, const OpenBabel::OBMol &first, const OpenBabel::OBMol &current)
-      {
-        if (!c) {
-          // this is the first molecule read
-          m_moleculeFile->setConformerFile(true);
-          addConformer(current);
-          return;
-        }
-
-        if (!m_moleculeFile->isConformerFile())
-          return;
-
-        // as long as we are not sure if this really is a 
-        // conformer/trajectory file, add the conformers
-        addConformer(current);
-
-        // performance: check only certain molecule 1-10,20,50
-        switch (c) {
-          case 1:
-          case 2:
-          case 3:
-          case 4:
-          case 5:
-          case 6:
-          case 7:
-          case 8:
-          case 9:
-          case 10:
-          case 20:
-          case 50:
-            break;
-          default:
-            return;
-        }
-
-        if (first.NumAtoms() != current.NumAtoms()) {
-          m_moleculeFile->setConformerFile(false);
-          m_moleculeFile->m_conformers.clear();
-          return;
-        }
-
-        for (unsigned int i = 0; i < first.NumAtoms(); ++i) {
-          OpenBabel::OBAtom *firstAtom = first.GetAtom(i+1);
-          OpenBabel::OBAtom *currentAtom = current.GetAtom(i+1);
-          if (firstAtom->GetAtomicNum() != currentAtom->GetAtomicNum()) {
-            m_moleculeFile->setConformerFile(false);
-            m_moleculeFile->m_conformers.clear();
-            return;
-          }    
-        }
-      }
-
-      void run()
-      {
-        // Check that the file can be read from disk
-        if (!MoleculeFile::canOpen(m_moleculeFile->m_fileName, QFile::ReadOnly | QFile::Text)) {
-          // Cannot read the file
-          m_moleculeFile->m_error.append(QObject::tr("File %1 cannot be opened for reading.")
-                                         .arg(m_moleculeFile->m_fileName));
-          return;
-        }
- 
-        // Construct the OpenBabel objects, set the file type
-        OpenBabel::OBConversion conv;
-        OpenBabel::OBFormat *inFormat;
-        if (!m_moleculeFile->m_fileType.isEmpty() && !conv.SetInFormat(m_moleculeFile->m_fileType.toAscii().data())) {
-          // Input format not supported
-          m_moleculeFile->m_error.append(
-              QObject::tr("File type '%1' is not supported for reading.").arg(m_moleculeFile->m_fileType));
-          return;
-        } else {
-          inFormat = conv.FormatFromExt(m_moleculeFile->m_fileName.toAscii().data());
-          if (!inFormat || !conv.SetInFormat(inFormat)) {
-            // Input format not supported
-            m_moleculeFile->m_error.append(QObject::tr("File type for file '%1' is not supported for reading.")
-                                           .arg(m_moleculeFile->m_fileName));
-            return;
-          }
-        }
-
-        // set any options
-        if (!m_moleculeFile->m_fileOptions.isEmpty()) {
-          foreach(const QString &option,
-              m_moleculeFile->m_fileOptions.split('\n', QString::SkipEmptyParts)) {
-            conv.AddOption(option.toAscii().data(), OBConversion::INOPTIONS);
-          }
-        }
-
-        // Now attempt to read the molecule in
-        ifstream ifs;
-        ifs.open(m_moleculeFile->m_fileName.toLocal8Bit()); // This handles utf8 file names etc
-        if (!ifs) // Should not happen, already checked file could be opened
-          return;
-      
-        // read all molecules
-        OpenBabel::OBMol firstOBMol, currentOBMol;
-        unsigned int c = 0;
-        conv.SetInStream(&ifs);
-        m_moleculeFile->streamposRef().push_back(ifs.tellg());
-        while (ifs.good() && conv.Read(&currentOBMol)) {
-          if (!c)
-            firstOBMol = currentOBMol;
-
-          if (c > 20 && !m_moleculeFile->isConformerFile())
-            m_moleculeFile->setFirstReady(true);
-
-          // detect conformer/trajectory files
-          detectConformers(c, firstOBMol, currentOBMol);
-          // store information about molecule
-          m_moleculeFile->streamposRef().push_back(ifs.tellg());
-          m_moleculeFile->titlesRef().append(currentOBMol.GetTitle());
-          // increment count
-          ++c;
-        }
-        m_moleculeFile->streamposRef().pop_back();
-
-        // signle molecule files are not conformer files
-        if (c == 1) {
-          m_moleculeFile->setConformerFile(false);
-          m_moleculeFile->m_conformers.clear();
-        }
-
-        // check for empty titles
-        for (int i = 0; i < m_moleculeFile->titlesRef().size(); ++i) {
-          if (!m_moleculeFile->titlesRef()[i].isEmpty())
-            continue;
-
-          QString title;
-          if (m_moleculeFile->isConformerFile())
-            title = tr("Conformer %1").arg(i+1);
-          else
-            title = tr("Molecule %1").arg(i+1);
-        
-          m_moleculeFile->titlesRef()[i] = title;
-        }
-      }
-
-      MoleculeFile *m_moleculeFile;
-  }; // end ReadFileThread class
-
   MoleculeFile* MoleculeFile::readFile(const QString &fileName,
       const QString &fileType, const QString &fileOptions, bool wait)
   {
@@ -794,6 +627,3 @@ namespace Avogadro {
   }
 
 } // end namespace Avogadro
-
-#include "moleculefile.moc"
-

--- a/libavogadro/src/moleculefile_p.h
+++ b/libavogadro/src/moleculefile_p.h
@@ -1,0 +1,202 @@
+/**********************************************************************
+  MoleculeFile - Class representing molecule file.
+
+  Copyright (C) 2009 Marcus Hanwell, Tim Vandermeersch
+
+  This file is part of the Avogadro molecular editor project.
+  For more information, see <http://avogadro.openmolecules.net/>
+
+  Avogadro is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  Avogadro is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+  02110-1301, USA.
+ **********************************************************************/
+
+#ifndef MOLECULEFILE_P_H
+#define MOLECULEFILE_P_H
+
+#include "moleculefile.h"
+
+#include <openbabel/mol.h>
+#include <openbabel/obconversion.h>
+
+#include <QFile>
+#include <QStringList>
+#include <QThread>
+
+namespace Avogadro {
+
+  using OpenBabel::OBConversion;
+  using std::ifstream;
+
+class ReadFileThread : public QThread
+{
+      Q_OBJECT
+
+  public:
+    ReadFileThread(MoleculeFile *moleculeFile) : m_moleculeFile(moleculeFile)
+    {
+    }
+
+    void addConformer(const OpenBabel::OBMol &conformer)
+    {
+      unsigned int numAtoms = conformer.NumAtoms();
+      std::vector<Eigen::Vector3d> *coords = new std::vector<Eigen::Vector3d>(numAtoms);
+      for (unsigned int i = 0; i < numAtoms; ++i)
+        coords->push_back(Eigen::Vector3d(conformer.GetAtom(i+1)->GetVector().AsArray()));
+      m_moleculeFile->m_conformers.push_back(coords);
+    }
+
+    void detectConformers(unsigned int c, const OpenBabel::OBMol &first, const OpenBabel::OBMol &current)
+    {
+      if (!c) {
+        // this is the first molecule read
+        m_moleculeFile->setConformerFile(true);
+        addConformer(current);
+        return;
+      }
+
+      if (!m_moleculeFile->isConformerFile())
+        return;
+
+      // as long as we are not sure if this really is a
+      // conformer/trajectory file, add the conformers
+      addConformer(current);
+
+      // performance: check only certain molecule 1-10,20,50
+      switch (c) {
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+        case 5:
+        case 6:
+        case 7:
+        case 8:
+        case 9:
+        case 10:
+        case 20:
+        case 50:
+          break;
+        default:
+          return;
+      }
+
+      if (first.NumAtoms() != current.NumAtoms()) {
+        m_moleculeFile->setConformerFile(false);
+        m_moleculeFile->m_conformers.clear();
+        return;
+      }
+
+      for (unsigned int i = 0; i < first.NumAtoms(); ++i) {
+        OpenBabel::OBAtom *firstAtom = first.GetAtom(i+1);
+        OpenBabel::OBAtom *currentAtom = current.GetAtom(i+1);
+        if (firstAtom->GetAtomicNum() != currentAtom->GetAtomicNum()) {
+          m_moleculeFile->setConformerFile(false);
+          m_moleculeFile->m_conformers.clear();
+          return;
+        }
+      }
+    }
+
+    void run()
+    {
+      // Check that the file can be read from disk
+      if (!MoleculeFile::canOpen(m_moleculeFile->m_fileName, QFile::ReadOnly | QFile::Text)) {
+        // Cannot read the file
+        m_moleculeFile->m_error.append(QObject::tr("File %1 cannot be opened for reading.")
+                                       .arg(m_moleculeFile->m_fileName));
+        return;
+      }
+
+      // Construct the OpenBabel objects, set the file type
+      OpenBabel::OBConversion conv;
+      OpenBabel::OBFormat *inFormat;
+      if (!m_moleculeFile->m_fileType.isEmpty() && !conv.SetInFormat(m_moleculeFile->m_fileType.toAscii().data())) {
+        // Input format not supported
+        m_moleculeFile->m_error.append(
+            QObject::tr("File type '%1' is not supported for reading.").arg(m_moleculeFile->m_fileType));
+        return;
+      } else {
+        inFormat = conv.FormatFromExt(m_moleculeFile->m_fileName.toAscii().data());
+        if (!inFormat || !conv.SetInFormat(inFormat)) {
+          // Input format not supported
+          m_moleculeFile->m_error.append(QObject::tr("File type for file '%1' is not supported for reading.")
+                                         .arg(m_moleculeFile->m_fileName));
+          return;
+        }
+      }
+
+      // set any options
+      if (!m_moleculeFile->m_fileOptions.isEmpty()) {
+        foreach(const QString &option,
+            m_moleculeFile->m_fileOptions.split('\n', QString::SkipEmptyParts)) {
+          conv.AddOption(option.toAscii().data(), OBConversion::INOPTIONS);
+        }
+      }
+
+      // Now attempt to read the molecule in
+      ifstream ifs;
+      ifs.open(m_moleculeFile->m_fileName.toLocal8Bit()); // This handles utf8 file names etc
+      if (!ifs) // Should not happen, already checked file could be opened
+        return;
+
+      // read all molecules
+      OpenBabel::OBMol firstOBMol, currentOBMol;
+      unsigned int c = 0;
+      conv.SetInStream(&ifs);
+      m_moleculeFile->streamposRef().push_back(ifs.tellg());
+      while (ifs.good() && conv.Read(&currentOBMol)) {
+        if (!c)
+          firstOBMol = currentOBMol;
+
+        if (c > 20 && !m_moleculeFile->isConformerFile())
+          m_moleculeFile->setFirstReady(true);
+
+        // detect conformer/trajectory files
+        detectConformers(c, firstOBMol, currentOBMol);
+        // store information about molecule
+        m_moleculeFile->streamposRef().push_back(ifs.tellg());
+        m_moleculeFile->titlesRef().append(currentOBMol.GetTitle());
+        // increment count
+        ++c;
+      }
+      m_moleculeFile->streamposRef().pop_back();
+
+      // signle molecule files are not conformer files
+      if (c == 1) {
+        m_moleculeFile->setConformerFile(false);
+        m_moleculeFile->m_conformers.clear();
+      }
+
+      // check for empty titles
+      for (int i = 0; i < m_moleculeFile->titlesRef().size(); ++i) {
+        if (!m_moleculeFile->titlesRef()[i].isEmpty())
+          continue;
+
+        QString title;
+        if (m_moleculeFile->isConformerFile())
+          title = tr("Conformer %1").arg(i+1);
+        else
+          title = tr("Molecule %1").arg(i+1);
+
+        m_moleculeFile->titlesRef()[i] = title;
+      }
+    }
+
+    MoleculeFile *m_moleculeFile;
+};
+
+} // end namespace Avogadro
+
+#endif // MOLECULEFILE_P_H

--- a/libavogadro/src/periodictablescene_p.cpp
+++ b/libavogadro/src/periodictablescene_p.cpp
@@ -213,5 +213,3 @@ namespace Avogadro {
   }
 
 } // End namespace Avogadro
-
-#include "periodictablescene_p.moc"

--- a/libavogadro/src/periodictableview.cpp
+++ b/libavogadro/src/periodictableview.cpp
@@ -69,4 +69,3 @@ namespace Avogadro {
 
 } // End namespace Avogadro
 
-#include "periodictableview.moc"

--- a/libavogadro/src/plotwidget.cpp
+++ b/libavogadro/src/plotwidget.cpp
@@ -27,7 +27,6 @@
  **********************************************************************/
 
 #include "plotwidget.h"
-#include "plotwidget.moc"
 
 #include <math.h>
 #include <QDebug>

--- a/libavogadro/src/plugin.cpp
+++ b/libavogadro/src/plugin.cpp
@@ -65,5 +65,3 @@ namespace Avogadro {
   }
 
 } // end namespace Avogadro
-
-#include "plugin.moc"

--- a/libavogadro/src/pluginmanager.cpp
+++ b/libavogadro/src/pluginmanager.cpp
@@ -784,5 +784,3 @@ namespace Avogadro {
   }
 
 }
-
-#include "pluginmanager.moc"

--- a/libavogadro/src/primitive.cpp
+++ b/libavogadro/src/primitive.cpp
@@ -77,5 +77,3 @@ namespace Avogadro {
   }
 
 }
-
-#include "primitive.moc"

--- a/libavogadro/src/protein.cpp
+++ b/libavogadro/src/protein.cpp
@@ -978,5 +978,3 @@ namespace Avogadro {
   }
 
 } // End namespace Avogadro
-
-#include "protein.moc"

--- a/libavogadro/src/python/CMakeLists.txt
+++ b/libavogadro/src/python/CMakeLists.txt
@@ -11,9 +11,9 @@ include_directories(
 # use all cpp files in this directory
 FILE(GLOB wrapper_SRCS "*.cpp")
 
-qt4_automoc(moleculelist.cpp)
+QT4_WRAP_CPP(MOC_SRCS moleculelist.h)
 
-ADD_LIBRARY(python-module MODULE ${wrapper_SRCS})
+ADD_LIBRARY(python-module MODULE ${wrapper_SRCS} ${MOC_SRCS})
 SET_TARGET_PROPERTIES(python-module PROPERTIES OUTPUT_NAME Avogadro)
 SET_TARGET_PROPERTIES(python-module PROPERTIES PREFIX "")
 if (WIN32)

--- a/libavogadro/src/python/moleculelist.cpp
+++ b/libavogadro/src/python/moleculelist.cpp
@@ -70,4 +70,3 @@ void export_MoleculeList()
 
 }
 
-#include "moleculelist.moc"

--- a/libavogadro/src/pythonengine_p.cpp
+++ b/libavogadro/src/pythonengine_p.cpp
@@ -289,5 +289,3 @@ namespace Avogadro {
 
 
 }
-
-#include "pythonengine_p.moc"

--- a/libavogadro/src/pythonerror.cpp
+++ b/libavogadro/src/pythonerror.cpp
@@ -112,4 +112,3 @@ namespace Avogadro
 
 } // namespace
 
-#include "pythonerror.moc"

--- a/libavogadro/src/pythonextension_p.cpp
+++ b/libavogadro/src/pythonextension_p.cpp
@@ -340,5 +340,3 @@ namespace Avogadro
   }
 
 }
-
-#include "pythonextension_p.moc"

--- a/libavogadro/src/pythontool_p.cpp
+++ b/libavogadro/src/pythontool_p.cpp
@@ -344,5 +344,3 @@ namespace Avogadro {
   }
 
 }
-
-#include "pythontool_p.moc"

--- a/libavogadro/src/residue.cpp
+++ b/libavogadro/src/residue.cpp
@@ -160,6 +160,3 @@ namespace Avogadro {
   }
 
 } // End namespace Avogadro
-
- #include "residue.moc"
-

--- a/libavogadro/src/tool.cpp
+++ b/libavogadro/src/tool.cpp
@@ -117,5 +117,3 @@ namespace Avogadro {
   }
 
 } // end namespace Avogadro
-
-#include "tool.moc"

--- a/libavogadro/src/toolgroup.cpp
+++ b/libavogadro/src/toolgroup.cpp
@@ -206,5 +206,3 @@ namespace Avogadro {
   }
 
 } // end namespace Avogadro
-
-#include "toolgroup.moc"

--- a/libavogadro/src/zmatrix.cpp
+++ b/libavogadro/src/zmatrix.cpp
@@ -149,5 +149,3 @@ namespace Avogadro{
 
 
 } // End namespace Avogadro
-
-#include "zmatrix.moc"


### PR DESCRIPTION
Hi Avogadro team,
I'm the avogadro maintainer in Arch Linux.

We are updating boost to 1.48.0, but Qt moc has a bug with this boost version (you can find more info here[1]).
Avogadro uses moc, so avogadro has this bug too. In fact when you build avogadro 1.0.3 with boost 1.48.0 you get:

[  4%] Generating pythonextension_p.moc
usr/include/boost/type_traits/detail/has_binary_operator.hp:50: Parse error at "BOOST_JOIN"
make[2]: **\* [libavogadro/src/pythonextension_p.moc] Error 1
make[1]: **\* [libavogadro/src/CMakeFiles/avogadro.dir/all] Error 2

In the qt bug report an user said that passing a specific option to moc the bug can be avoided.
But the only one method to pass some option to moc in cmake is the QT4_WRAP_CPP macro.
You use this macro in the libavogadro/CMakeLists.txt, but you don't in libavogadro/src/CMakeLists.txt and libavogadro/src/python/CMakeLists.txt; you use qt4_automoc there.
So I replaced qt4_automoc usage with the qt4_wrap_cpp macro in those CMakeLists.txt.

You would merge my commit.
Note, I had to move the ReadFileThread class declaration in another header (moleculefile_p.h) to make the macro work.

Cheers.

[1] https://bugreports.qt.nokia.com/browse/QTBUG-22829
