### PR TITLE
Avoid TEXTRELS https://bugs.gentoo.org/show_bug.cgi?id=439410

### DIFF
--- a/libavogadro/src/extensions/crystallography/spglib/CMakeLists.txt
+++ b/libavogadro/src/extensions/crystallography/spglib/CMakeLists.txt
@@ -20,6 +20,6 @@ add_library(spglib STATIC ${spglib_SRCS})
 set_target_properties(spglib PROPERTIES COMPILE_FLAGS "-w")
 
 # Set -fPIC on x86_64
-if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "^(i.86|x86|x86_64)$")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC"  )
 endif()


### PR DESCRIPTION
In order to avoid TEXTRELs (https://bugs.gentoo.org/show_bug.cgi?id=439410)
we need to add fPic on 32bit too.

Signed-off-by: Justin Lecher <jlec@gentoo.org>