### PR TITLE
Fix build with boost 1.53

### DIFF
--- a/libavogadro/src/pythonengine_p.h
+++ b/libavogadro/src/pythonengine_p.h
@@ -27,7 +27,9 @@
 
 #include <avogadro/global.h>
 #include <avogadro/engine.h>
+#ifndef Q_MOC_RUN
 #include <boost/python.hpp>
+#endif
 
 namespace Avogadro {
 

--- a/libavogadro/src/pythonextension_p.h
+++ b/libavogadro/src/pythonextension_p.h
@@ -29,7 +29,9 @@
 #include <avogadro/extension.h>
 #include <avogadro/primitive.h>
 #include <avogadro/glwidget.h>
+#ifndef Q_MOC_RUN
 #include <boost/python.hpp>
+#endif
 
 #include <QWidget>
 #include <QList>

--- a/libavogadro/src/pythoninterpreter.h
+++ b/libavogadro/src/pythoninterpreter.h
@@ -26,7 +26,9 @@
 #define PYTHONINTERPRETER_H
 
 #include <avogadro/global.h>
+#ifndef Q_MOC_RUN
 #include <boost/python.hpp>
+#endif
 #include <avogadro/primitive.h>
 #include <QString>
 

--- a/libavogadro/src/pythonscript.h
+++ b/libavogadro/src/pythonscript.h
@@ -27,7 +27,9 @@
 #define PYTHONSCRIPT_H
 
 #include <avogadro/global.h>
+#ifndef Q_MOC_RUN
 #include <boost/python.hpp>
+#endif
 
 #include "pythonerror.h"
 

--- a/libavogadro/src/pythontool_p.h
+++ b/libavogadro/src/pythontool_p.h
@@ -27,7 +27,9 @@
 
 #include <avogadro/global.h>
 #include <avogadro/tool.h>
+#ifndef Q_MOC_RUN
 #include <boost/python.hpp>
+#endif
 
 #include <QObject>
 #include <QAction>


### PR DESCRIPTION
Using boost 1.53 the build fails. This is due to a bug in Qt4 (https://bugreports.qt-project.org/browse/QTBUG-22829)

This change is safe, see also https://bugs.kde.org/show_bug.cgi?id=304111