### PR TITLE
Treat "amd64" as a possible value for CMAKE_SYSTEM_PROCESSOR.

### DIFF
--- a/libavogadro/src/extensions/crystallography/spglib/CMakeLists.txt
+++ b/libavogadro/src/extensions/crystallography/spglib/CMakeLists.txt
@@ -20,6 +20,6 @@ add_library(spglib STATIC ${spglib_SRCS})
 set_target_properties(spglib PROPERTIES COMPILE_FLAGS "-w")
 
 # Set -fPIC on x86_64
-if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64" OR "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "amd64")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC"  )
 endif()

--- a/libavogadro/src/extensions/swcntbuilder/tubegen/CMakeLists.txt
+++ b/libavogadro/src/extensions/swcntbuilder/tubegen/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(tubegen STATIC ${tubegen_SRCS})
 set_target_properties(tubegen PROPERTIES COMPILE_FLAGS "-w")
 
 # Set -fPIC on x86_64
-if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64" OR "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "amd64")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC"  )
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC"  )
 endif()


### PR DESCRIPTION
The BSDs (and maybe OS X) report 64-bits sytems as "amd64" instead of
"x86_64", so accept that value when deciding whether to pass -fPIC to the
compiler too.
