### PR TITLE
Fix for BOOST_JOIN errors.

### DIFF
--- a/libavogadro/src/pythonengine_p.h
+++ b/libavogadro/src/pythonengine_p.h
@@ -25,9 +25,13 @@
 #ifndef PYTHONENGINE_H
 #define PYTHONENGINE_H
 
+#ifndef Q_MOC_RUN
+#include <boost/python.hpp>
+#endif
+
 #include <avogadro/global.h>
 #include <avogadro/engine.h>
-#include <boost/python.hpp>
+
 
 namespace Avogadro {
 

--- a/libavogadro/src/pythonextension_p.h
+++ b/libavogadro/src/pythonextension_p.h
@@ -26,10 +26,14 @@
 #ifndef PYTHONEXTENSION_H
 #define PYTHONEXTENSION_H
 
+#ifndef Q_MOC_RUN
+#include <boost/python.hpp>
+#endif
+
 #include <avogadro/extension.h>
 #include <avogadro/primitive.h>
 #include <avogadro/glwidget.h>
-#include <boost/python.hpp>
+
 
 #include <QWidget>
 #include <QList>

--- a/libavogadro/src/pythoninterpreter.h
+++ b/libavogadro/src/pythoninterpreter.h
@@ -26,7 +26,9 @@
 #define PYTHONINTERPRETER_H
 
 #include <avogadro/global.h>
+#ifndef Q_MOC_RUN
 #include <boost/python.hpp>
+#endif
 #include <avogadro/primitive.h>
 #include <QString>
 

--- a/libavogadro/src/pythonscript.h
+++ b/libavogadro/src/pythonscript.h
@@ -27,7 +27,9 @@
 #define PYTHONSCRIPT_H
 
 #include <avogadro/global.h>
+#ifndef Q_MOC_RUN
 #include <boost/python.hpp>
+#endif
 
 #include "pythonerror.h"
 

--- a/libavogadro/src/pythontool_p.h
+++ b/libavogadro/src/pythontool_p.h
@@ -25,9 +25,13 @@
 #ifndef PYTHONTOOL_H
 #define PYTHONTOOL_H
 
+#ifndef Q_MOC_RUN
+#include <boost/python.hpp>
+#endif
+
 #include <avogadro/global.h>
 #include <avogadro/tool.h>
-#include <boost/python.hpp>
+
 
 #include <QObject>
 #include <QAction>


### PR DESCRIPTION
Hello :-)

Fist things.. nice project!! i like avogadro and i use it for teaching and not only :+1: 

Second things... i'm trying to make a formula for homebrew in osx.. however i got some compilation error such as BOOST_JOIN using boost 1.56 and i have seen that there are a lot of bug reports without a real fix. So, i've resolved the problem fixing pythonengine_p.h, pythonextension_p.h, pythoninterpreter.h, pythonscript.h and pythontool_p.h. Here i submit to you this pull request in order to integrate this if you are interested. 

Best Regards

Giuseppe Marco Randazzo
