### PR TITLE
cppcheck: some cleanings

### DIFF
--- a/libavogadro/src/extensions/quantuminput/gamessinputdata.cpp
+++ b/libavogadro/src/extensions/quantuminput/gamessinputdata.cpp
@@ -1651,8 +1651,8 @@ short GamessDataGroup::SetTitle( const char *NewTitle, long length )
 
   long TitleStart=0, TitleEnd=length-1, i, j;
   //Strip blanks of both ends of title
-  while (( NewTitle[TitleStart] <= ' ' )&&( TitleStart<length ) ) TitleStart ++;
-  while (( NewTitle[TitleEnd] <= ' ' )&&( TitleEnd>0 ) ) TitleEnd --;
+  while ( ( TitleStart<length )&&(NewTitle[TitleStart] <= ' ' ) ) TitleStart ++;
+  while (( TitleEnd>0 )&&( NewTitle[TitleEnd] <= ' ' ) ) TitleEnd --;
   length = TitleEnd - TitleStart + 1;
 
   if ( length <= 0 ) return 0;

--- a/libavogadro/src/extensions/surfaces/openqube/gaussianset.cpp
+++ b/libavogadro/src/extensions/surfaces/openqube/gaussianset.cpp
@@ -289,6 +289,7 @@ void GaussianSet::initCalculation()
   // Add a final entry to the gtoIndices
   m_gtoIndices.push_back(m_gtoA.size());
   for(unsigned int i = 0; i < m_symmetry.size(); ++i) {
+    bool bSkipCanBeUsed = true;
     switch (m_symmetry[i]) {
     case S:
       m_moIndices[i] = indexMO++;
@@ -413,16 +414,36 @@ void GaussianSet::initCalculation()
       break;
     case G:
       skip = 15;
+      bSkipCanBeUsed = false;
     case G9:
-      skip = 9;
+      if (bSkipCanBeUsed)
+      {
+        skip = 9;
+        bSkipCanBeUsed = false;
+      }
     case H:
-      skip = 21;
+      if (bSkipCanBeUsed)
+      {
+        skip = 21;
+        bSkipCanBeUsed = false;
+      }
     case H11:
-      skip = 11;
+      if (bSkipCanBeUsed)
+      {
+        skip = 11;
+        bSkipCanBeUsed = false;
+      }
     case I:
-      skip = 28;
+      if (bSkipCanBeUsed)
+      {
+        skip = 28;
+        bSkipCanBeUsed = false;
+      }
     case I13:
-      skip = 13;
+      if (bSkipCanBeUsed)
+      {
+        skip = 13;
+      }
 
       m_moIndices[i] = indexMO;
       indexMO += skip;

--- a/libavogadro/src/python/sip.cpp
+++ b/libavogadro/src/python/sip.cpp
@@ -402,8 +402,8 @@ PyObject* toPyQt(T *obj)
   PyObject *sip_obj = sip_API->api_convert_from_instance(obj, type, 0);
 #endif
   if (!sip_obj) {
-    return incref(Py_None);
     std::cout << "toPyQt: could not convert";
+    return incref(Py_None);
   }
 
   return incref(sip_obj);

--- a/libavogadro/src/textrenderer_p.cpp
+++ b/libavogadro/src/textrenderer_p.cpp
@@ -212,7 +212,11 @@ namespace Avogadro {
     //     much it is surrounded by other pixels.
 
     int *neighborhood = new int[ texwidth * texheight ];
-    if( ! neighborhood ) return false;
+    if( ! neighborhood )
+    {
+      delete [] rawbitmap;
+      return false;
+    }
     for( int i = 0; i < texheight * texwidth; i++)
       neighborhood[i] = 0;
 
@@ -244,9 +248,20 @@ namespace Avogadro {
     //     alpha channel is a bit more involved and uses the neighborhood map.
 
     GLubyte *glyphbitmap = new GLubyte[ texwidth * texheight ];
-    if( ! glyphbitmap ) return false;
+    if( ! glyphbitmap )
+    {
+      delete [] rawbitmap;
+      delete [] neighborhood;
+      return false;
+    }
     GLubyte *outlinebitmap = new GLubyte[ texwidth * texheight ];
-    if( ! outlinebitmap ) return false;
+    if( ! outlinebitmap )
+    {
+      delete [] rawbitmap;
+      delete [] neighborhood;
+      delete [] outlinebitmap;
+      return false;
+    }
 
     for( int n = 0; n < texwidth * texheight; n++ )
     {


### PR DESCRIPTION
[libavogadro/src/textrenderer_p.cpp:215]: (error) Memory leak: rawbitmap
[libavogadro/src/textrenderer_p.cpp:249]: (error) Memory leak: glyphbitmap
[libavogadro/src/textrenderer_p.cpp:267]: (error) Memory leak: outlinebitmap
[libavogadro/src/extensions/surfaces/openqube/gaussianset.cpp:415] -> [libavogadro/src/extensions/surfaces/openqube/gaussianset.cpp:417]: (warning) Variable 'skip' is reassigned a value before the old one has been used. 'break;' missing?
[libavogadro/src/extensions/surfaces/openqube/gaussianset.cpp:417] -> [libavogadro/src/extensions/surfaces/openqube/gaussianset.cpp:419]: (warning) Variable 'skip' is reassigned a value before the old one has been used. 'break;' missing?
[libavogadro/src/extensions/surfaces/openqube/gaussianset.cpp:419] -> [libavogadro/src/extensions/surfaces/openqube/gaussianset.cpp:421]: (warning) Variable 'skip' is reassigned a value before the old one has been used. 'break;' missing?
[libavogadro/src/extensions/surfaces/openqube/gaussianset.cpp:421] -> [libavogadro/src/extensions/surfaces/openqube/gaussianset.cpp:423]: (warning) Variable 'skip' is reassigned a value before the old one has been used. 'break;' missing?
[libavogadro/src/extensions/surfaces/openqube/gaussianset.cpp:423] -> [libavogadro/src/extensions/surfaces/openqube/gaussianset.cpp:425]: (warning) Variable 'skip' is reassigned a value before the old one has been used. 'break;' missing?
[libavogadro/src/extensions/quantuminput/gamessinputdata.cpp:42]: (style) Array index 'test' is used before limits check.
[libavogadro/src/extensions/quantuminput/gamessinputdata.cpp:1654]: (style) Array index 'TitleStart' is used before limits check.