### PR TITLE
Explicitly look for X11 when using it.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,10 @@ find_package(Eigen2 REQUIRED) # find and setup Eigen2
 find_package(ZLIB REQUIRED)
 find_package(OpenBabel2 REQUIRED) # find and setup OpenBabel
 
+if (Q_WS_X11)
+  find_package(X11 REQUIRED) # avogadro/src/main.cpp calls XInitThread().
+endif()
+
 # Check if we are building from a Git clone or a released version
 function(git_version dir version_var)
   # Function to figure out the Git short version hash


### PR DESCRIPTION
This fixes the build with CMake 3.2, whose FindOpenGL.cmake stopped
calling `find_package(X11)`.

Instead, do that ourselves when `Q_WS_X11` is true, since that is when we
already try to link against libX11.

(It's not clear if this repository will ever be updated given Avogadro2 is being worked on, but this patch might interest other packagers who come across the same problem)