### PR TITLE
Added the configured 'config.h' to the libavogadro_HDRS list.

### DIFF
--- a/libavogadro/src/CMakeLists.txt
+++ b/libavogadro/src/CMakeLists.txt
@@ -36,6 +36,7 @@ set(libavogadro_HDRS
   color3f.h
   colorbutton.h
   color.h
+  ${CMAKE_CURRENT_BINARY_DIR}/config.h
   cube.h
   dockextension.h
   dockwidget.h


### PR DESCRIPTION
Since commit e573850a8dd3d3de6bd8423f92b93c3fa53ff2dc (Merge pull request #8 from ktns/feature/eigen3) was made a few days ago, I've been having issues in Ubuntu with the header files that get installed in the ${CMAKE_INSTALL_PREFIX}/include/avogadro directory. A "#include config.h" was added to the top of a lot of header files, and this file isn't installed into the include directory.

So when I include some of the avogadro header files in my avogadro extension (XtalOpt), I get an error that "config.h" wasn't found (since it is currently only put in the build directory and not installed to the include directory). In addition, it's a cmake configured file (config.h.in), so the configured file needs to be installed. This will probably be an issue for anyone who wants to include avogadro header files as well in a program they are using.

This is a fix that I tried that appears to work. There may be a better fix, though. Let me know what you think.