### PR TITLE
Fix bug with dipole moments reported by Steven Petrovic

### DIFF
--- a/libavogadro/src/molecule.cpp
+++ b/libavogadro/src/molecule.cpp
@@ -777,11 +777,17 @@ namespace Avogadro{
     else {
       // Calculate a new estimate (e.g., the geometry changed
       Vector3d dipoleMoment(0.0, 0.0, 0.0);
+
       foreach (Atom *a, atoms())
         dipoleMoment += *a->pos() * a->partialCharge();
 
+      // convert from electrons * Angstrom to Debye
+      // (1.602176487×10−19 C / electron) *  (1.0e-10 m/Ang / 3.33564e-30 C/m)
+      dipoleMoment *= 4.80321;
+
       if (estimate)
         *estimate = true;
+
       m_estimatedDipoleMoment = true;
       return dipoleMoment;
     }


### PR DESCRIPTION
Dipole moments were left as electron*Angstrom, not Debye.
The bug probably occured with removal of the empirical correction
in 2009.

Change-Id: Idecb47ecaefea804b50d784b514c882466f2bca6