### PR TITLE
Updated libmsym with the most recent libmsym patch that supports C++. 

### DIFF
--- a/libavogadro/src/extensions/symmetry/CMakeLists.txt
+++ b/libavogadro/src/extensions/symmetry/CMakeLists.txt
@@ -18,4 +18,5 @@ avogadro_plugin(symmetryextension
 
 add_subdirectory(libmsym)
 
+set_target_properties(msym PROPERTIES POSITION_INDEPENDENT_CODE "TRUE")
 target_link_libraries(symmetryextension msym)

--- a/libavogadro/src/extensions/symmetry/libmsym/README.md
+++ b/libavogadro/src/extensions/symmetry/libmsym/README.md
@@ -1,4 +1,4 @@
-# libmsym
+# LIBrary for Molecular SYMmetry
 
 libmsym is a C library dealing with point group symmetry in molecules. It can determine, symmetrize and generate molecules of any point group. It can also generate symmetry adapted linear combinations of atomic orbitals for a subset of all point groups and orbital angular momentum (l), and project orbitals into the irreducible representation with the larges component.
 

--- a/libavogadro/src/extensions/symmetry/libmsym/src/context.c
+++ b/libavogadro/src/extensions/symmetry/libmsym/src/context.c
@@ -296,6 +296,8 @@ msym_error_t msymGetSubgroups(msym_context ctx, int *sgl, msym_subgroup_t **sg){
             ctx->ext.sg[i].sops = malloc(sizeof(msym_symmetry_operation_t *[ctx->sg[i].sopsl]));
             for(int j = 0;j < ctx->sg[i].sopsl;j++){
                 ctx->ext.sg[i].sops[j] = ctx->sg[i].sops[j] - ctx->pg->sops + ctx->ext.sops;
+                ctx->ext.sg[i].subgroup[0] = ctx->sg[i].subgroup[0] == NULL ? NULL : ctx->sg[i].subgroup[0] - ctx->sg + ctx->ext.sg;
+                ctx->ext.sg[i].subgroup[1] = ctx->sg[i].subgroup[1] == NULL ? NULL : ctx->sg[i].subgroup[1] - ctx->sg + ctx->ext.sg;
             }
         }
     }

--- a/libavogadro/src/extensions/symmetry/libmsym/src/msym.h
+++ b/libavogadro/src/extensions/symmetry/libmsym/src/msym.h
@@ -139,10 +139,10 @@ extern "C" {
     
     msym_error_t msymSetThresholds(msym_context ctx, msym_thresholds_t *thresholds);
     msym_error_t msymGetThresholds(msym_context ctx, msym_thresholds_t **thresholds);
-    msym_error_t msymSetElements(msym_context ctx, int length, msym_element_t elements[length]);
+    msym_error_t msymSetElements(msym_context ctx, int length, msym_element_t *elements);
     msym_error_t msymGetElements(msym_context ctx, int *length, msym_element_t **elements);
     msym_error_t msymSetPointGroup(msym_context ctx, char *name);
-    msym_error_t msymGetPointGroup(msym_context ctx, int l, char buf[l]);
+    msym_error_t msymGetPointGroup(msym_context ctx, int l, char *buf);
     msym_error_t msymGetSubgroups(msym_context ctx, int *l, msym_subgroup_t **subgroups);
     msym_error_t msymSelectSubgroup(msym_context ctx, msym_subgroup_t *subgroup);
     msym_error_t msymGetSymmetryOperations(msym_context ctx, int *sopsl, msym_symmetry_operation_t **sops);
@@ -153,10 +153,15 @@ extern "C" {
     msym_error_t msymFindSymmetry(msym_context ctx);
     msym_error_t msymSymmetrizeMolecule(msym_context context, double *err);
     msym_error_t msymApplyTranslation(msym_context ctx, msym_element_t *element, double v[3]);
-    msym_error_t msymSymmetrizeOrbitals(msym_context ctx, int l, double c[l][l]);
-    msym_error_t msymGenerateElements(msym_context ctx, int length, msym_element_t elements[length]);
+#ifdef __cplusplus //VLA invalid in  C++
+    msym_error_t msymSymmetrizeOrbitals(msym_context ctx, int l, void *c);
+    msym_error_t msymGetOrbitalSubspaces(msym_context ctx, int l, void *c);
+#else
+    msym_error_t msymSymmetrizeOrbitals(msym_context ctx, int l, double (*c)[]);
+    msym_error_t msymGetOrbitalSubspaces(msym_context ctx, int l, double (*c)[]);
+#endif
+    msym_error_t msymGenerateElements(msym_context ctx, int length, msym_element_t *elements);
     msym_error_t msymGenerateOrbitalSubspaces(msym_context ctx);
-    msym_error_t msymGetOrbitalSubspaces(msym_context ctx, int l, double c[l][l]);
     msym_error_t msymAlignAxes(msym_context ctx);
     
     msym_error_t msymGetCenterOfMass(msym_context ctx, double v[3]);

--- a/libavogadro/src/extensions/symmetry/libmsym/src/msym_error.c
+++ b/libavogadro/src/extensions/symmetry/libmsym/src/msym_error.c
@@ -9,6 +9,7 @@
 //
 
 #include <stdarg.h>
+#include <stdio.h>
 #include "msym_error.h"
 
 

--- a/libavogadro/src/extensions/symmetry/libmsym/src/msym_error.h
+++ b/libavogadro/src/extensions/symmetry/libmsym/src/msym_error.h
@@ -15,8 +15,6 @@
 extern "C" {
 #endif
 
-#include <stdio.h>
-
     enum _msym_error {
         MSYM_SUCCESS = 0,
         MSYM_INVALID_INPUT = -1,

--- a/libavogadro/src/extensions/symmetry/symmetryextension.cpp
+++ b/libavogadro/src/extensions/symmetry/symmetryextension.cpp
@@ -47,44 +47,44 @@ namespace Avogadro {
 #define DEFAULT_ORTHOGONALIZATION_THRESHOLD 0.1
 
 
-  msym_thresholds_t tight_thresholds = { // all defaults
-    .zero = 1.0e-3,
-    .geometry = 1.0e-3,
-    .angle = 1.0e-3,
-    .equivalence = 5.0e-4,
-    .permutation = 5.0e-3,
-    .eigfact = 1.0e-3,
-    .orthogonalization = 0.1
+msym_thresholds_t tight_thresholds = { // all defaults
+    1.0e-3, // zero
+    1.0e-3, // geometry
+    1.0e-3, // angle
+    5.0e-4, // equivalence
+    5.0e-3, // permutation
+    1.0e-3, // eigfact
+    0.1 // orthogonalization
 };
 
 msym_thresholds_t medium_thresholds = {
-    .zero = 1.0e-2,
-    .geometry = 1.0e-2,
-    .angle = 1.0e-2,
-    .equivalence = 6.3e-3,
-    .permutation = 1.58e-2,
-    .eigfact = 1.0e-3,
-    .orthogonalization = 0.1
+    1.0e-2, // zero
+    1.0e-2, // geometry
+    1.0e-2, // angle
+    6.3e-3, // equivalence
+    1.58e-2, // permutation
+    1.0e-3, // eigfact
+    0.1 // orthogonalization
 };
 
 msym_thresholds_t loose_thresholds = {
-    .zero = 0.06,
-    .geometry = 0.06,
-    .angle = 0.06,
-    .equivalence = 0.025,
-    .permutation = 1.0e-1,
-    .eigfact = 1.0e-3,
-    .orthogonalization = 0.1
+    0.06, // zero
+    0.06, // geometry
+    0.06, // angle
+    0.025, // equivalence
+    1.0e-1, // permutation
+    1.0e-3, // eigfact
+    0.1 // orthogonalization
 };
 
 msym_thresholds_t sloppy_thresholds = {
-    .zero = 0.08,
-    .geometry = 0.1,
-    .angle = 0.1,
-    .equivalence = 0.06,
-    .permutation = 1.0e-1,
-    .eigfact = 1.0e-3,
-    .orthogonalization = 0.1
+    0.08, // zero
+    0.1, // geometry
+    0.1, // angle
+    0.06, // equivalence
+    1.0e-1, // permutation
+    1.0e-3, // eigfact
+    0.1 // orthognalization
 };
 
   SymmetryExtension::SymmetryExtension(QObject *parent) : Extension(parent),
@@ -184,15 +184,8 @@ msym_thresholds_t sloppy_thresholds = {
     // interface with libmsym
     msym_error_t ret = MSYM_SUCCESS;
     msym_element_t *elements = NULL;
-    const char *error = NULL;
     char point_group[6];
-    double cm[3], radius = 0.0, symerr = 0.0;
     unsigned int length = m_molecule->numAtoms();
-
-    /* Do not free these variables */
-    msym_symmetry_operation_t *msops = NULL;
-    msym_subgroup_t *msg = NULL;
-    int msgl = 0, msopsl = 0, mlength = 0;
 
     // initialize the c-style array of atom names and coordinates
     msym_element_t *a;


### PR DESCRIPTION
Also changed C-style designated initialization of structs to C++ style initialization of structs in symmetryextension.cpp (will not compile otherwise). Also deleted unused variables in symmetryextension.cpp to eliminate compiler warnings. Added "-fPIC" flag for GNU compilers. May need to add flags for other compilers as well.