### PR TITLE
cppcheck: fix some reports

### DIFF
--- a/libavogadro/src/extensions/cartesianextension.cpp
+++ b/libavogadro/src/extensions/cartesianextension.cpp
@@ -410,7 +410,7 @@ namespace Avogadro
         }
 
         it=tmpMap.constBegin();
-        for (int i=0; it !=tmpMap.constEnd(); i++,it++ )
+        for (int i=0; it !=tmpMap.constEnd(); i++,++it )
           localAtom.push_back(it.value());
 
         matrix3x3 xform;

--- a/libavogadro/src/extensions/quantuminput/gamessinputdata.cpp
+++ b/libavogadro/src/extensions/quantuminput/gamessinputdata.cpp
@@ -39,7 +39,7 @@ namespace Avogadro
       if ( pos>=bytecount ) return -1;
       if ( Buffer[pos]=='\0' ) return -1;
       test = 2;
-      while (( Buffer[pos+test] == KeyWord[test] )&&( test<length ) ) test++;
+      while (( test<length ) && ( Buffer[pos+test] == KeyWord[test] ) ) test++;
       test = ( long ) test==length;
     }
     return pos;

--- a/libavogadro/src/textrenderer_p.cpp
+++ b/libavogadro/src/textrenderer_p.cpp
@@ -260,6 +260,7 @@ namespace Avogadro {
       delete [] rawbitmap;
       delete [] neighborhood;
       delete [] outlinebitmap;
+      delete [] glyphbitmap;
       return false;
     }
 


### PR DESCRIPTION
[libavogadro/src/extensions/cartesianextension.cpp:413]: (performance) Prefer prefix ++/-- operators for non-primitive types
[libavogadro/src/textrenderer_p.cpp:263]: (error) Memory leak: glyphbitmap
[libavogadro/src/extensions/quantuminput/gamessinputdata.cpp:42]: (style) Array index 'test' is used before limits check