### PR TITLE
Fix some cppcheck reports

### DIFF
--- a/libavogadro/src/extensions/crystallography/spglib/pointgroup.c
+++ b/libavogadro/src/extensions/crystallography/spglib/pointgroup.c
@@ -695,7 +695,7 @@ static int laue2m(int axes[3],
 static int lauemmm(int axes[3],
 		   SPGCONST PointSymmetry * pointsym)
 {
-  int i, count, axis, tmpval;
+  int i, count, axis;
   int prop_rot[3][3];
 
 
@@ -980,7 +980,7 @@ static int laue3m(int axes[3],
 static int lauem3m(int axes[3],
 		   SPGCONST PointSymmetry * pointsym)
 {
-  int i, count, axis, tmpval;
+  int i, count, axis;
   int prop_rot[3][3];
 
   for (i = 0; i < 3; i++) { axes[i] = -1; }

--- a/libavogadro/src/textrenderer_p.cpp
+++ b/libavogadro/src/textrenderer_p.cpp
@@ -280,9 +280,17 @@ namespace Avogadro {
     // *** STEP 5 : pass the final bitmap to OpenGL for texturing ***
 
     glGenTextures( 1, &m_glyphTexture );
-    if( ! m_glyphTexture ) return false;
+    if( ! m_glyphTexture )
+    {
+      delete [] glyphbitmap;
+      return false;
+    }
     glGenTextures( 1, &m_outlineTexture );
-    if( ! m_outlineTexture ) return false;
+    if( ! m_outlineTexture )
+    {
+      delete [] glyphbitmap;
+      return false;
+    }
 
     glPixelStorei( GL_UNPACK_ALIGNMENT, 1 );
 


### PR DESCRIPTION
[libavogadro/src/extensions/crystallography/spglib/pointgroup.c:698]: (style) Unused variable: tmpval
[libavogadro/src/extensions/crystallography/spglib/pointgroup.c:983]: (style) Unused variable: tmpval
[libavogadro/src/textrenderer_p.cpp:283]: (error) Memory leak: glyphbitmap