### PR TITLE
Work around doc limitations with Boost Python

### DIFF
--- a/libavogadro/src/extensions/pythonterminal.h
+++ b/libavogadro/src/extensions/pythonterminal.h
@@ -23,6 +23,10 @@
 #ifndef PYTHONTERMINAL_H
 #define PYTHONTERMINAL_H
 
+#ifdef Q_MOC_RUN
+#define BOOST_TT_HAS_OPERATOR_HPP_INCLUDED
+#endif
+
 #include <avogadro/dockextension.h>
 #include <avogadro/primitive.h>
 #include <avogadro/glwidget.h>

--- a/libavogadro/src/pythonengine_p.h
+++ b/libavogadro/src/pythonengine_p.h
@@ -25,6 +25,10 @@
 #ifndef PYTHONENGINE_H
 #define PYTHONENGINE_H
 
+#ifdef Q_MOC_RUN
+#define BOOST_TT_HAS_OPERATOR_HPP_INCLUDED
+#endif
+
 #include <avogadro/global.h>
 #include <avogadro/engine.h>
 #include <boost/python.hpp>

--- a/libavogadro/src/pythonextension_p.h
+++ b/libavogadro/src/pythonextension_p.h
@@ -26,6 +26,10 @@
 #ifndef PYTHONEXTENSION_H
 #define PYTHONEXTENSION_H
 
+#ifdef Q_MOC_RUN
+#define BOOST_TT_HAS_OPERATOR_HPP_INCLUDED
+#endif
+
 #include <avogadro/extension.h>
 #include <avogadro/primitive.h>
 #include <avogadro/glwidget.h>

--- a/libavogadro/src/pythontool_p.h
+++ b/libavogadro/src/pythontool_p.h
@@ -25,6 +25,10 @@
 #ifndef PYTHONTOOL_H
 #define PYTHONTOOL_H
 
+#ifdef Q_MOC_RUN
+#define BOOST_TT_HAS_OPERATOR_HPP_INCLUDED
+#endif
+
 #include <avogadro/global.h>
 #include <avogadro/tool.h>
 #include <boost/python.hpp>


### PR DESCRIPTION
Change-Id: I2a12390283dc592eb931fd4eee2d5681883e5414
 Some parts of Boost, introduced in Boost 1.48 are not
 understood by the limited C++ parser of moc.  This
 patch defines header guards that prevent the troublesome boost
 headers from being processed.
Bug-Debian: http://bugs.debian.org/653625
Author: Tobias Frost <tobi@coldtobi.de>
Reviewed-By: Steve Robbins <smr@debian.org>