### PR TITLE
probe X11 paths with find_package(X11)

### DIFF
--- a/avogadro/src/CMakeLists.txt
+++ b/avogadro/src/CMakeLists.txt
@@ -116,6 +116,7 @@ if(QtTesting)
   target_link_libraries(avogadro-app QtTesting)
 endif()
 if(Q_WS_X11)
+  find_package(X11 REQUIRED)
   target_link_libraries(avogadro-app ${X11_X11_LIB})
 endif()
 


### PR DESCRIPTION
Change-Id: I5565402faf9fba709b40e39918dc3b84ee8a3b76
 cmake no longer automatically probes for X11 when probling for QT et al.
 We now need to manually load X11 when needed.
Author: Andy Whitcroft <apw@ubuntu.com>