### PR TITLE
Fixed a problem with reading POSCARs.

### DIFF
--- a/libavogadro/src/extensions/crystallography/crystalpastedialog.cpp
+++ b/libavogadro/src/extensions/crystallography/crystalpastedialog.cpp
@@ -435,6 +435,15 @@ namespace Avogadro {
                        (Eigen2OB(*it)));
       }
     }
+    // If cartesian, we need to scale the atoms with the scaling factor
+    else {
+      for (QList<Eigen::Vector3d>::iterator
+             it = positions.begin(),
+             it_end = positions.end();
+           it != it_end; ++it) {
+        *it *= scale;
+      }
+    }
 
     // Remove old atoms
     QList<Avogadro::Atom*> oldAtoms = m_molecule->atoms();


### PR DESCRIPTION
According to the POSCAR file description at http://cms.mpi.univie.ac.at/vasp/vasp/POSCAR_file.html: "The second line provides a universal scaling factor ('lattice constant'), which is used to scale all lattice vectors and all atomic coordinates." When using Cartesian coordinates, we need to scale the coordinates of the atoms with the scaling factor.