### PR TITLE
Conditionally compile the symmetry extension - default off for Win.

### DIFF
--- a/libavogadro/src/extensions/CMakeLists.txt
+++ b/libavogadro/src/extensions/CMakeLists.txt
@@ -121,12 +121,22 @@ target_link_libraries(networkfetchextension ${QT_QTNETWORK_LIBRARY})
 avogadro_plugin(gl2psextension
   "gl2psextension.cpp;gl2ps/gl2ps.c")
 
+# Symmetry (libmsym) has compile issues on Windows
+# due to VLA not supported by C compiler
+include(CMakeDependentOption)
+cmake_dependent_option(BUILD_SYMMETRY
+  "Build symmetry extension and libmsym - not supported with Visual Studio" ON
+  "MSVC" OFF)
+
+if(BUILD_SYMMETRY)
+  add_subdirectory(symmetry)
+endif()
+
 # Subdirs
 add_subdirectory(crystallography)
 add_subdirectory(spectra)
 add_subdirectory(surfaces)
 add_subdirectory(swcntbuilder)
-add_subdirectory(symmetry)
 add_subdirectory(qtaim)
 add_subdirectory(quantuminput)
 add_subdirectory(orca)


### PR DESCRIPTION
Since Visual Studio doesn't support VLA used in libmsym - for now, turn off the symmetry extension on Windows.