### PR TITLE
Added custom string options for plot axes

### DIFF
--- a/libavogadro/src/plotaxis.h
+++ b/libavogadro/src/plotaxis.h
@@ -113,6 +113,10 @@ namespace Avogadro {
      * Note that when the format character is 't', the fieldWidth and prec
      * values are ignored.
      *
+     * If the format character is set to 'c', the tick marks should be
+     * set by the user using setCustomTickStrings(). The tick marks
+     * are simply custom strings in this case.
+     *
      * @param format the format specification character
      * @param fieldWidth the number of characters in the output string.
      * If set to 0, the string will be as wide as it needs to be to fully
@@ -146,6 +150,18 @@ namespace Avogadro {
      * @sa minorTickMarks()
      */
     void setTickMarks( double x0, double length );
+
+    /**
+     * Set custom strings for tick marks at specific values.
+     * This function automatically sets the tick format to be 'c', the
+     * format for custom tick marks.
+     * @param values The values for the tick marks to be set. Must be equal
+     *               in size to 'strings'.
+     * @param strings The strings for the tick marks to be set. Must be equal
+     *                in size to 'values'.
+     */
+    void setTickCustomStrings( const QList<double>& values,
+                               const QStringList& strings );
 
     /**
      * @return the list of coordinates of the major tickmarks for this axis

--- a/libavogadro/src/plotwidget.cpp
+++ b/libavogadro/src/plotwidget.cpp
@@ -184,7 +184,7 @@ namespace Avogadro {
       if (po->points().isEmpty()) return;
       xmin = xmax = po->points().first()->x();
       ymin = ymax = po->points().first()->y();
-      
+
       foreach ( PlotPoint *pp, po->points() ) {
         if (pp->x() < xmin) xmin = pp->x();
         if (pp->x() > xmax) xmax = pp->x();
@@ -640,7 +640,7 @@ namespace Avogadro {
           if (newX1 > defaultDataRect().left() || (newX2 < defaultDataRect().right())) {
             newX1 = dataRect().x();
             newX2 = dataRect().x() + dataRect().width();
-          }            
+          }
         }
         if (defaultDataRect().height() > 0) {
           if (newY1 < defaultDataRect().top() || (newY2 > defaultDataRect().bottom())) {
@@ -653,7 +653,7 @@ namespace Avogadro {
             newY2 = dataRect().y() + dataRect().height();
           }
         }
-      }      
+      }
       setLimits(newX1, newX2, newY1, newY2);
       mouseClickOrigin = event->posF();
     }
@@ -697,7 +697,7 @@ namespace Avogadro {
       QPointF pF ( mapToWidget(mapFrameToData(event->pos())));
       QPoint p_widget ( static_cast<int>(pF.x()), static_cast<int>(pF.y()));
       QPointF p_data = mapFrameToData(event->posF());
-      PlotPoint *p_near = pointNearestPoint(p_widget); 
+      PlotPoint *p_near = pointNearestPoint(p_widget);
       emit pointClicked(p_data.x(), p_data.y());
       emit pointClicked(pointsUnderPoint(p_widget));
       if (p_near) emit pointClicked(p_near);
@@ -915,7 +915,7 @@ namespace Avogadro {
     float xStep = 0.5*bestRect.width();
     float yStep = 0.5*bestRect.height();
      switch(d->labelShiftDirection) {
-      case Up:        
+      case Up:
         bestRect = fm.boundingRect( QRectF( pos.x(), pos.y()-3*yStep, 1, 1 ), textFlags, pp->label() );
         break;
       case Down:
@@ -957,7 +957,7 @@ namespace Avogadro {
       QRectF upRect = bestRect;
       upRect.moveTop( upRect.top() + yStep );
       if (d->labelShiftDirection != Down)
-        upCost = d->rectCost( upRect );        
+        upCost = d->rectCost( upRect );
       QRectF downRect = bestRect;
       downRect.moveTop( downRect.top() - yStep );
       if (d->labelShiftDirection != Up)
@@ -1040,7 +1040,7 @@ namespace Avogadro {
           iter = -1; //anticipating the ++iter below
     // TODO: remove code duplication
      switch(d->labelShiftDirection) {
-      case Up:        
+      case Up:
         bestRect = fm.boundingRect( QRectF( pos.x(), pos.y()-3*yStep, 1, 1 ), textFlags, pp->label() );
         break;
       case Down:
@@ -1070,11 +1070,11 @@ namespace Avogadro {
       ++iter;
     }
 
-    QPen oldpen = painter->pen();      
+    QPen oldpen = painter->pen();
     QPen pen(oldpen);
     pen.setColor(d->cForeground);
     painter->setPen( pen );
-      
+
     //Place label
     painter->drawText( bestRect, textFlags, pp->label() );
 


### PR DESCRIPTION
I have used this for my band structures. Instead of having
a number on the x axis, it is ideal for band structures to
have a symbol representing a point in reciprocal space. This
update allows me to set an axes to have strings at specific
values via the function:
setTickCustomStrings(const QList<double>& values,
                     const QStringList& strings);

If you put in a list of doubles and list of strings (they
must be matching size), then the corresponding string will
be drawn at the location given by the value in values.