### PR TITLE
Add backers and sponsors from Open Collective

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![GitHub release](https://img.shields.io/github/release/cryos/avogadro.svg?maxAge=86400)](https://sourceforge.net/projects/avogadro/files/latest/download)
 [![Download Avogadro](https://img.shields.io/sourceforge/dt/avogadro.svg?maxAge=86400)](https://sourceforge.net/projects/avogadro/files/latest/download)
 [![Google Scholar Citations](https://avogadro.cc/citations.svg?maxAge=86400)](https://scholar.google.com/scholar?cites=618227831851025693&as_sdt=5,38&sciodt=0,38&hl=en)
+[![OpenCollective](https://opencollective.com/avogadro/backers/badge.svg)](#backers) 
+[![OpenCollective](https://opencollective.com/avogadro/sponsors/badge.svg)](#sponsors)
+
 
 Avogadro is an advanced molecular editor designed for cross-platform use
 in computational chemistry, molecular modeling, bioinformatics, materials
@@ -34,3 +37,69 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 See INSTALL file for installation instructions.
+
+# Backers
+Support us with a monthly donation and help us continue our activities. [[Become a backer](https://opencollective.com/avogadro#backer)]
+<a href="https://opencollective.com/avogadro/backer/0/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/0/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/1/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/1/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/2/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/2/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/3/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/3/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/4/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/4/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/5/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/5/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/6/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/6/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/7/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/7/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/8/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/8/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/9/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/9/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/10/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/10/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/11/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/11/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/12/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/12/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/13/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/13/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/14/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/14/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/15/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/15/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/16/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/16/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/17/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/17/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/18/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/18/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/19/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/19/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/20/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/20/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/21/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/21/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/22/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/22/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/23/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/23/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/24/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/24/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/25/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/25/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/26/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/26/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/27/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/27/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/28/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/28/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/backer/29/website" target="_blank"><img src="https://opencollective.com/avogadro/backer/29/avatar.svg"></a>
+
+# tSponsors
+Become a sponsor and get your logo on our README on Github with a link to your site. [[Become a sponsor](https://opencollective.com/avogadro#sponsor)]
+<a href="https://opencollective.com/avogadro/sponsor/0/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/0/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/1/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/1/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/2/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/2/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/3/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/3/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/4/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/4/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/5/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/5/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/6/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/6/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/7/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/7/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/8/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/8/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/9/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/9/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/10/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/10/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/11/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/11/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/12/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/12/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/13/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/13/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/14/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/14/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/15/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/15/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/16/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/16/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/17/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/17/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/18/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/18/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/19/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/19/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/20/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/20/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/21/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/21/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/22/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/22/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/23/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/23/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/24/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/24/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/25/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/25/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/26/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/26/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/27/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/27/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/28/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/28/avatar.svg"></a>
+<a href="https://opencollective.com/avogadro/sponsor/29/website" target="_blank"><img src="https://opencollective.com/avogadro/sponsor/29/avatar.svg"></a>


### PR DESCRIPTION
Now your open collective backers and sponsors can to appear directly on your README. 
see how it'll look [here](https://github.com/apex/apex#backers)
[More info](https://github.com/opencollective/opencollective/wiki/Github-banner)
Also add badges on top.