### PR TITLE
Improve usability of the animation dialog.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,4 +14,5 @@ Jordan Mantha <jordan.mantha@gmail.com>
 Carsten Niehaus <cniehaus@kde.org>
 Simon Ochsenreither <simon@ochsenreither.de>
 Konstantin Tokarev <annulen@yandex.ru>
+David Toneian <david@toneian.com>
 Tim Vandermeersch <tim.vandermeersch@gmail.com>

--- a/libavogadro/src/animation.h
+++ b/libavogadro/src/animation.h
@@ -34,7 +34,7 @@
 
 #include <vector>
 
-class QTimeLine;
+class QTimer;
 
 namespace Avogadro {
 
@@ -93,9 +93,9 @@ namespace Avogadro {
        */
       int fps() const;
       /**
-       * @return The loopCount (0 = repeat forever).
+       * @return Whether to loop the animation.
        */
-      int loopCount() const;
+      bool loop() const;
       /**
        * @return The total number of frames in the animation.
        */
@@ -117,13 +117,26 @@ namespace Avogadro {
        */
       void setFps(int fps);
       /**
-       * Set the loop count. (0 = repeat forever)
+       * Set whether to loop the animation.
        */
-      void setLoopCount(int loops);
+      void setLoop(const bool loop);
       /**
        * Set the current frame. 
        */
       void setFrame(int i);
+
+      /**
+       * React to changes to the slider by updating the state of the time line.
+       */
+      void sliderChanged(int i);
+      /**
+       * React to the slider being pressed by pausing the animation.
+       */
+      void sliderPressed();
+      /**
+       * React to the slider being released by unpausing the animation.
+       */
+      void sliderReleased();
 
       /**
        * Enable/disable dynamic bond detection. For QM reactions for example.
@@ -143,11 +156,22 @@ namespace Avogadro {
        */
       void stop();
 
+      /**
+       * Proceeds to the next frame, or loops or stops the animation.
+       */
+      void timerFired();
+
+    private:
+      /**
+       * Starts the timer with the appropriate timeout interval.
+       */
+      void startTimer();
+
     private:
       AnimationPrivate * const d;
       
       Molecule *m_molecule;
-      QTimeLine *m_timeLine;
+      QTimer *m_timer;
       std::vector< std::vector< Eigen::Vector3d> *> m_originalConformers;
       std::vector< std::vector< Eigen::Vector3d> *> m_frames;
   };

--- a/libavogadro/src/extensions/animationdialog.cpp
+++ b/libavogadro/src/extensions/animationdialog.cpp
@@ -43,6 +43,8 @@ namespace Avogadro {
     ui.setupUi(this);
     connect(ui.loadButton, SIGNAL(clicked()), this, SLOT(loadFile()));
     connect(ui.frameSlider, SIGNAL(valueChanged(int)), this, SIGNAL(sliderChanged(int)));
+    connect(ui.frameSlider, SIGNAL(sliderPressed()), this, SIGNAL(sliderPressed()));
+    connect(ui.frameSlider, SIGNAL(sliderReleased()), this, SIGNAL(sliderReleased()));
     connect(ui.fpsSpin, SIGNAL(valueChanged(int)), this, SIGNAL(fpsChanged(int)));
     connect(ui.loopBox, SIGNAL(stateChanged(int)), this, SIGNAL(loopChanged(int)));
     connect(ui.dynBondsBox, SIGNAL(stateChanged(int)), this, SIGNAL(dynamicBondsChanged(int)));

--- a/libavogadro/src/extensions/animationdialog.h
+++ b/libavogadro/src/extensions/animationdialog.h
@@ -56,6 +56,8 @@ namespace Avogadro
       void fileName(QString filename);
       void videoFileInfo(QString filename); 
       void sliderChanged(int i);
+      void sliderPressed();
+      void sliderReleased();
       void fpsChanged(int i);
       void dynamicBondsChanged(int state);
       bool loopChanged(int state);

--- a/libavogadro/src/extensions/animationextension.cpp
+++ b/libavogadro/src/extensions/animationextension.cpp
@@ -96,7 +96,9 @@ namespace Avogadro {
       m_animationDialog = new AnimationDialog(static_cast<QWidget*>(parent()));
 
       connect(m_animationDialog, SIGNAL(fileName(QString)), this, SLOT(loadFile(QString)));
-      connect(m_animationDialog, SIGNAL(sliderChanged(int)), m_animation, SLOT(setFrame(int)));
+      connect(m_animationDialog, SIGNAL(sliderChanged(int)), m_animation, SLOT(sliderChanged(int)));
+      connect(m_animationDialog, SIGNAL(sliderPressed()), m_animation, SLOT(sliderPressed()));
+      connect(m_animationDialog, SIGNAL(sliderReleased()), m_animation, SLOT(sliderReleased()));
       connect(m_animationDialog, SIGNAL(fpsChanged(int)), m_animation, SLOT(setFps(int)));
       connect(m_animationDialog, SIGNAL(loopChanged(int)), this, SLOT(setLoop(int)));
       connect(m_animationDialog, SIGNAL(dynamicBondsChanged(int)), this, SLOT(setDynamicBonds(int)));
@@ -157,11 +159,7 @@ namespace Avogadro {
 
   void AnimationExtension::setLoop(int state)
   {
-    if (state == Qt::Checked) {
-      m_animation->setLoopCount(0);
-    } else {
-      m_animation->setLoopCount(1);
-    }
+    m_animation->setLoop(state == Qt::Checked);
   }
 
   void AnimationExtension::setDynamicBonds(int state)

--- a/libavogadro/src/extensions/orca/orcaanalysedialog.cpp
+++ b/libavogadro/src/extensions/orca/orcaanalysedialog.cpp
@@ -306,7 +306,7 @@ bool OrcaAnalyseDialog::createAnimation()
 
     m_animation->setFrame(1);
     m_animation->setFps(10);
-    m_animation->setLoopCount(0);
+    m_animation->setLoop(true);
     m_animation->setFrames(m_curFrames);
     m_animation->setMolecule(m_molecule);
 

--- a/libavogadro/src/extensions/spectra/vibrationextension.cpp
+++ b/libavogadro/src/extensions/spectra/vibrationextension.cpp
@@ -120,7 +120,7 @@ namespace Avogadro {
                 this, SLOT(showSpectra()));
         m_dialog->setMolecule(m_molecule);
         m_animation = new Animation(this);
-        m_animation->setLoopCount(0); // continual loopback
+        m_animation->setLoop(true);
       }
     }
     m_dock->setWidget(m_dialog);


### PR DESCRIPTION
Prior to these changes, one was unable to (effectively) manipulate the slider in a running animation, and pressing the "play" button in a paused animation would restart the animation.
This commit, hopefully, makes the user interface more intuitive and useful, and reduces code complexity by using the more straightforward QTimer rather than QTimeLine.

Lastly, this commit makes the code correspond more closely to the user interface, by removing the `Animation::setLoopCount` function in favor of `setLoop`.
This does not remove functionality, since after all, the user is anyway only able to specify whether the animation should loop, indefinitely so, or not loop at all.
Furthermore, the need to show exactly X repetitions of the animation probably arises very rarely.
This change made changes to the `orca` and `sepctra` extensions necessary.

This commit is released to the public domain.