### PR TITLE
Calculate in 1-D or 2-D plus several minor changes

### DIFF
--- a/libavogadro/src/extensions/yaehmop/numvalenceelectrons.h
+++ b/libavogadro/src/extensions/yaehmop/numvalenceelectrons.h
@@ -18,9 +18,9 @@
 #define NUMVALENCEELECTRONS_H
 
 /* Returns the number of valence electrons for the neutral element with
- * atomic number @atomicNum. Full d and f shells do not count towards
- * the number of valence electrons (except in cases like copper in which
- * the s orbital is not filled either).
+ * atomic number @atomicNum. Full d and f shells DO count towards
+ * the number of valence electrons. The numbers only go up to 90. They are
+ * set to match that of YAeHMOP.
  *
  * @param atomicNum The atomic number of the element of interest.
  * @return The number of valence electrons for the element (assuming it is
@@ -49,14 +49,6 @@ static unsigned char numValenceElectrons(unsigned char atomicNum)
   case 38:
   case 56:
   case 88:
-  // Zinc group
-  case 30:
-  case 48:
-  case 80:
-  case 112:
-  // Ytterbium group (maybe this group should have 16 valence electrons...)
-  case 70:
-  case 102:
     return 2;
 
   // Boron group
@@ -65,12 +57,9 @@ static unsigned char numValenceElectrons(unsigned char atomicNum)
   case 31:
   case 49:
   case 81:
-  case 113:
   // Scandium group
   case 21:
   case 39:
-  case 71:
-  case 103:
   // Lanthanum group
   case 57:
   case 89:
@@ -82,15 +71,12 @@ static unsigned char numValenceElectrons(unsigned char atomicNum)
   case 32:
   case 50:
   case 82:
-  case 114:
   // Titanium group
   case 22:
   case 40:
   case 72:
-  case 104:
   // Cerium group
   case 58:
-  case 90:
     return 4;
 
   // Pnictogens
@@ -99,15 +85,12 @@ static unsigned char numValenceElectrons(unsigned char atomicNum)
   case 33:
   case 51:
   case 83:
-  case 115:
   // Vanadium group
   case 23:
   case 41:
   case 73:
-  case 105:
   // Praseodymium group
   case 59:
-  case 91:
     return 5;
 
   // Chalcogens
@@ -116,15 +99,12 @@ static unsigned char numValenceElectrons(unsigned char atomicNum)
   case 34:
   case 52:
   case 84:
-  case 116:
   // Chromium group
   case 24:
   case 42:
   case 74:
-  case 106:
   // Neodymium group
   case 60:
-  case 92:
     return 6;
 
   // Halogens
@@ -133,15 +113,12 @@ static unsigned char numValenceElectrons(unsigned char atomicNum)
   case 35:
   case 53:
   case 85:
-  case 117:
   // Manganese group
   case 25:
   case 43:
   case 75:
-  case 107:
   // Promethium group
   case 61:
-  case 93:
     return 7;
 
   // Noble gases (other than helium)
@@ -150,66 +127,65 @@ static unsigned char numValenceElectrons(unsigned char atomicNum)
   case 36:
   case 54:
   case 86:
-  case 118:
   // Iron group
   case 26:
   case 44:
   case 76:
-  case 108:
   // Samarium group
   case 62:
-  case 94:
     return 8;
 
   // Cobalt group
   case 27:
   case 45:
   case 77:
-  case 109:
   // Europeum group
   case 63:
-  case 95:
     return 9;
 
   // Nickel group
   case 28:
   case 46:
   case 78:
-  case 110:
   // Gadolinium group
   case 64:
-  case 96:
     return 10;
 
   // Copper group
   case 29:
   case 47:
   case 79:
-  case 111:
   // Terbium group
   case 65:
-  case 97:
     return 11;
 
+  // Zinc group
+  case 30:
+  case 48:
+  case 80:
   // Dysprosium group
   case 66:
-  case 98:
     return 12;
 
   // Holmium group
   case 67:
-  case 99:
     return 13;
 
   // Erbium group
   case 68:
-  case 100:
     return 14;
 
   // Thulium group
   case 69:
-  case 101:
     return 15;
+
+  // Ytterbium group
+  case 70:
+    return 16;
+
+  // Lutetium
+  case 71:
+    return 17;
 
   // Hopefully we won't get here
   default:

--- a/libavogadro/src/extensions/yaehmop/yaehmopbanddialog.cpp
+++ b/libavogadro/src/extensions/yaehmop/yaehmopbanddialog.cpp
@@ -36,12 +36,13 @@ namespace Avogadro {
     delete m_ui;
   }
 
-  bool YaehmopBandDialog::getKPointInfo(Molecule* mol, size_t& numKPoints,
-                                        QString& kPointInfo,
-                                        bool& displayBandData, bool& limitY,
-                                        double& minY, double& maxY,
-                                        bool& plotFermi, double& fermi,
-                                        bool& zeroFermi)
+  bool YaehmopBandDialog::getUserOptions(Molecule* mol, size_t& numKPoints,
+                                         QString& kPointInfo,
+                                         bool& displayBandData, bool& limitY,
+                                         double& minY, double& maxY,
+                                         bool& plotFermi, double& fermi,
+                                         bool& zeroFermi,
+                                         unsigned short& numDimensions)
   {
     m_ui->spin_numKPoints->setValue(numKPoints);
     m_ui->cb_displayBandData->setChecked(displayBandData);
@@ -51,6 +52,7 @@ namespace Avogadro {
     m_ui->cb_plotFermi->setChecked(plotFermi);
     m_ui->spin_fermi->setValue(fermi);
     m_ui->cb_zeroFermi->setChecked(zeroFermi);
+    m_ui->spin_numDim->setValue(numDimensions);
 
     kPointInfo = "";
     QString specialKPoints = SpecialKPoints::getSpecialKPoints(mol);
@@ -101,6 +103,8 @@ namespace Avogadro {
     plotFermi = m_ui->cb_plotFermi->isChecked();
     fermi = m_ui->spin_fermi->value();
     zeroFermi = (plotFermi ? m_ui->cb_zeroFermi->isChecked() : false);
+    numDimensions = m_ui->spin_numDim->value();
+
     return true;
   }
 

--- a/libavogadro/src/extensions/yaehmop/yaehmopbanddialog.h
+++ b/libavogadro/src/extensions/yaehmop/yaehmopbanddialog.h
@@ -56,12 +56,18 @@ public:
   //              true.
   // @param zeroFermi Whether or not to zero the Fermi level. This will only
   //                  take effect if plotFermi is true.
+  // @param numDimensions The number of dimensions. If this is 1, then
+  //                      periodicity is only along the A vector. If this
+  //                      is 2, then periodicity is along both the A and
+  //                      the B vectors. If it is 3, then periodicity is
+  //                      along all three vectors.
   // If the user checks the box to display band data, displayBandData
   // will be set to be true
-  bool getKPointInfo(Molecule* mol, size_t& numKPoints,
-                     QString& kPointInfo, bool& displayBandData,
-                     bool& limitY, double& minY, double& maxY, bool& plotFermi,
-                     double& fermi, bool& zeroFermi);
+  bool getUserOptions(Molecule* mol, size_t& numKPoints,
+                      QString& kPointInfo, bool& displayBandData,
+                      bool& limitY, double& minY, double& maxY, bool& plotFermi,
+                      double& fermi, bool& zeroFermi,
+                      unsigned short& numDimensions);
 
   void displayInvalidFormatMessage();
 

--- a/libavogadro/src/extensions/yaehmop/yaehmopbanddialog.ui
+++ b/libavogadro/src/extensions/yaehmop/yaehmopbanddialog.ui
@@ -192,6 +192,38 @@ p, li { white-space: pre-wrap; }
      </property>
     </widget>
    </item>
+   <item row="11" column="2">
+    <widget class="QLabel" name="label_3">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The number of periodic dimensions.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If this is set to 1, the material will be periodic only along the A vector of the crystal.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If this is set to 2, the material will be periodic along both the A and B vectors of the crystal.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If this is set to 3, the material will be periodic along the A, B, and C vectors of the crystal.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="layoutDirection">
+      <enum>Qt::LeftToRight</enum>
+     </property>
+     <property name="text">
+      <string>Num Dimensions:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="3">
+    <widget class="QSpinBox" name="spin_numDim">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The number of periodic dimensions.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If this is set to 1, the material will be periodic only along the A vector of the crystal.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If this is set to 2, the material will be periodic along both the A and B vectors of the crystal.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If this is set to 3, the material will be periodic along the A, B, and C vectors of the crystal.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>3</number>
+     </property>
+     <property name="value">
+      <number>3</number>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <tabstops>

--- a/libavogadro/src/extensions/yaehmop/yaehmopextension.h
+++ b/libavogadro/src/extensions/yaehmop/yaehmopextension.h
@@ -19,8 +19,6 @@
 
 #include <avogadro/extension.h>
 
-#include <QMutex>
-
 namespace Avogadro {
 
   class YaehmopExtension : public Extension
@@ -37,6 +35,8 @@ namespace Avogadro {
     virtual QString menuPath(QAction *action) const;
 
     virtual void setMolecule(Molecule *molecule);
+    Molecule* getMolecule() { return m_molecule; };
+    const Molecule* getMolecule() const { return m_molecule; };
 
     virtual QDockWidget * dockWidget();
     virtual QUndoCommand* performAction(QAction *action, GLWidget *widget);
@@ -60,7 +60,6 @@ namespace Avogadro {
   public slots:
     void calculateBandStructure();
     void calculateTotalDOS();
-    void plotPartialDOS();
     void setParametersFile();
     void executeCustomInput() const;
 
@@ -105,6 +104,7 @@ namespace Avogadro {
     // This is just the Fermi level the user sets in the band dialog
     double m_fermi;
     bool m_zeroFermi;
+    unsigned short m_numDimensions;
 
     QList<QAction *> m_actions;
     Molecule *m_molecule;

--- a/libavogadro/src/extensions/yaehmop/yaehmopout.cpp
+++ b/libavogadro/src/extensions/yaehmop/yaehmopout.cpp
@@ -44,10 +44,10 @@ bool YaehmopOut::readBandData(const QString& data, QVector<band>& bands,
 
   QStringList lines = data.split(QRegExp("[\r\n]"), QString::SkipEmptyParts);
 
-  while (lines.size() != 0 && !lines[0].contains("#BAND_DATA"))
+  while (!lines.isEmpty() && !lines[0].contains("#BAND_DATA"))
     lines.removeFirst();
 
-  if (lines.size() == 0)
+  if (lines.isEmpty())
     return printAndReturnFalse("Band Data not found in readBandData()!");
 
   // These get printed from the status file and are not needed...
@@ -179,8 +179,11 @@ bool YaehmopOut::readTotalDOSData(const QString& data,
 
   QStringList lines = data.split(QRegExp("[\r\n]"), QString::SkipEmptyParts);
 
-  while (!lines[0].contains("TOTAL DENSITY OF STATES"))
+  while (!lines.isEmpty() && !lines[0].contains("TOTAL DENSITY OF STATES"))
     lines.removeFirst();
+
+  if (lines.isEmpty())
+    return printAndReturnFalse("DOS Data not found in readTotalDOSData!");
 
   size_t ind = 1;
 

--- a/libavogadro/src/extensions/yaehmop/yaehmoptotaldosdialog.cpp
+++ b/libavogadro/src/extensions/yaehmop/yaehmoptotaldosdialog.cpp
@@ -36,17 +36,18 @@ namespace Avogadro {
     delete m_ui;
   }
 
-  bool YaehmopTotalDOSDialog::getNumValAndKPoints(YaehmopExtension* yext,
-                                                  size_t& numValElectrons,
-                                                  size_t& numKPoints,
-                                                  QString& kPoints,
-                                                  bool& displayDOSData,
-                                                  bool& useSmoothing,
-                                                  double& stepE,
-                                                  double& broadening,
-                                                  bool& limitY,
-                                                  double& minY, double& maxY,
-                                                  bool& zeroFermi)
+  bool YaehmopTotalDOSDialog::getUserOptions(YaehmopExtension* yext,
+                                             size_t& numValElectrons,
+                                             size_t& numKPoints,
+                                             QString& kPoints,
+                                             bool& displayDOSData,
+                                             bool& useSmoothing,
+                                             double& stepE,
+                                             double& broadening,
+                                             bool& limitY,
+                                             double& minY, double& maxY,
+                                             bool& zeroFermi,
+                                             unsigned short& numDimensions)
   {
     m_ui->spin_numValElectrons->setValue(numValElectrons);
     numKPoints = 0;
@@ -59,6 +60,7 @@ namespace Avogadro {
     m_ui->spin_minY->setValue(minY);
     m_ui->spin_maxY->setValue(maxY);
     m_ui->cb_zeroFermi->setChecked(zeroFermi);
+    m_ui->spin_numDim->setValue(numDimensions);
 
     if (this->exec() == QDialog::Rejected)
       return false;
@@ -177,6 +179,7 @@ namespace Avogadro {
     minY = m_ui->spin_minY->value();
     maxY = m_ui->spin_maxY->value();
     zeroFermi = m_ui->cb_zeroFermi->isChecked();
+    numDimensions = m_ui->spin_numDim->value();
 
     // We have to set this in here so we can keep the "text"
     yext->setDOSKPoints(text);

--- a/libavogadro/src/extensions/yaehmop/yaehmoptotaldosdialog.h
+++ b/libavogadro/src/extensions/yaehmop/yaehmoptotaldosdialog.h
@@ -62,15 +62,21 @@ public:
   // @param minY MinY if we are limiting the y-range.
   // @param maxY MaxY if we are limiting the y-range.
   // @param zeroFermi Whether or not to zero the Fermi level.
+  // @param numDimensions The number of dimensions. If this is 1, then
+  //                      periodicity is only along the A vector. If this
+  //                      is 2, then periodicity is along both the A and
+  //                      the B vectors. If it is 3, then periodicity is
+  //                      along all three vectors.
   // @return True if the parse was successful and the user did not cancel.
   //         False otherwise.
 
-  bool getNumValAndKPoints(YaehmopExtension* yext,
-                           size_t& numValElectrons, size_t& numKPoints,
-                           QString& kPoints, bool& displayDOSData,
-                           bool& useSmoothing, double& stepE,
-                           double& broadening, bool& limitY,
-                           double& minY, double& maxY, bool& zeroFermi);
+  bool getUserOptions(YaehmopExtension* yext,
+                      size_t& numValElectrons, size_t& numKPoints,
+                      QString& kPoints, bool& displayDOSData,
+                      bool& useSmoothing, double& stepE,
+                      double& broadening, bool& limitY,
+                      double& minY, double& maxY, bool& zeroFermi,
+                      unsigned short& numDimensions);
 
   void displayInvalidFormatMessage();
 

--- a/libavogadro/src/extensions/yaehmop/yaehmoptotaldosdialog.ui
+++ b/libavogadro/src/extensions/yaehmop/yaehmoptotaldosdialog.ui
@@ -6,67 +6,76 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>566</width>
+    <width>508</width>
     <height>429</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Yaehmop Total DOS</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="layoutDirection">
-      <enum>Qt::LeftToRight</enum>
-     </property>
-     <property name="text">
-      <string>Number of valence electrons:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>k points</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Energy step size:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QSpinBox" name="spin_numValElectrons">
+  <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0,0">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetDefaultConstraint</enum>
+   </property>
+   <item row="6" column="2" colspan="2">
+    <widget class="QCheckBox" name="cb_zeroFermi">
      <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter the number of k-points that will be connecting the special k-points. More of these k-points will smooth out the graph, but the calculation may take longer.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Subtracts the Fermi energy from all other energies so that the Fermi energy is set to be zero.&lt;/p&gt;&lt;p&gt;Default: off&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     <property name="text">
+      <string>Zero the Fermi level?</string>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="2" colspan="2">
+    <widget class="QDoubleSpinBox" name="spin_maxY">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="prefix">
+      <string>Max Y: </string>
      </property>
      <property name="suffix">
-      <string/>
+      <string> eV</string>
+     </property>
+     <property name="decimals">
+      <number>5</number>
      </property>
      <property name="minimum">
-      <number>0</number>
+      <double>-10000.000000000000000</double>
      </property>
      <property name="maximum">
-      <number>999999</number>
-     </property>
-     <property name="value">
-      <number>1</number>
+      <double>10000.000000000000000</double>
      </property>
     </widget>
    </item>
-   <item row="5" column="0" colspan="2">
+   <item row="18" column="1" colspan="3">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="3">
+    <widget class="QSpinBox" name="spin_numDim">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The number of periodic dimensions.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If this is set to 1, the material will be periodic only along the A vector of the crystal.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If this is set to 2, the material will be periodic along both the A and B vectors of the crystal.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If this is set to 3, the material will be periodic along the A, B, and C vectors of the crystal.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>3</number>
+     </property>
+     <property name="value">
+      <number>3</number>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="4">
     <widget class="QTextEdit" name="edit_kpoints">
      <property name="toolTip">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter the k-points for the calculation in a grid format as follows:&lt;/p&gt;&lt;p&gt;&amp;lt;l&amp;gt;x&amp;lt;m&amp;gt;x&amp;lt;n&amp;gt;&lt;/p&gt;&lt;p&gt;where l, m, and n are integers. For example, 5x5x5 would be a grid with 5 elements in every direction. You may also enter k-points in the following format:&lt;/p&gt;&lt;p&gt;&amp;lt;x&amp;gt; &amp;lt;y&amp;gt; &amp;lt;z&amp;gt; &amp;lt;weight&amp;gt;&lt;/p&gt;&lt;p&gt;where x, y, and z are the three dimensional coordinates of the k-point in reciprocal space, and the weight is the weight of the k-point. &lt;/p&gt;&lt;p&gt;More k-points will result in a more accurate calculation. However, your computer may shut down the process if it uses up too much memory.&lt;/p&gt;&lt;p&gt;Please note that the orientation of your cell may have an effect on the locations of these reciprocal space points.&lt;/p&gt;&lt;p&gt;Default: 15x15x15&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -80,17 +89,33 @@ p, li { white-space: pre-wrap; }
      </property>
     </widget>
    </item>
-   <item row="11" column="0">
-    <widget class="QLabel" name="label_4">
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="label">
+     <property name="layoutDirection">
+      <enum>Qt::LeftToRight</enum>
+     </property>
      <property name="text">
-      <string>Gaussian broadening:</string>
+      <string>Number of valence electrons:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="2">
+    <widget class="QLabel" name="label_6">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The number of periodic dimensions.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If this is set to 1, the material will be periodic only along the A vector of the crystal.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If this is set to 2, the material will be periodic along both the A and B vectors of the crystal.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If this is set to 3, the material will be periodic along the A, B, and C vectors of the crystal.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Num Dimensions:</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
+   <item row="8" column="2" colspan="2">
     <widget class="QCheckBox" name="cb_useSmoothing">
      <property name="toolTip">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Whether or not to use Gaussian smoothing to smooth the data.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Smoothing is typically performed for density of states data.&lt;/p&gt;&lt;p&gt;Default: on&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -103,7 +128,7 @@ p, li { white-space: pre-wrap; }
      </property>
     </widget>
    </item>
-   <item row="10" column="1">
+   <item row="10" column="2" colspan="2">
     <widget class="QDoubleSpinBox" name="spin_energyStep">
      <property name="toolTip">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The energy step size for Gaussian smoothing. &lt;/p&gt;&lt;p&gt;Default: 0.1&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -134,7 +159,76 @@ p, li { white-space: pre-wrap; }
      </property>
     </widget>
    </item>
-   <item row="11" column="1">
+   <item row="12" column="2" colspan="2">
+    <widget class="QCheckBox" name="cb_limitY">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Limit the y-range?&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Default: off&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Limit y-range?</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="2" colspan="2">
+    <widget class="QCheckBox" name="cb_displayData">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Whether or not to display the density of states data in a&lt;/p&gt;&lt;p&gt;pop-up box after the calculation finishes.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Data may be copied and pasted into a separate file.&lt;/p&gt;&lt;p&gt;Default: off&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Display DOS data?</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0" colspan="2">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Gaussian broadening:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="0" colspan="2">
+    <widget class="QDoubleSpinBox" name="spin_minY">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="prefix">
+      <string>Min Y: </string>
+     </property>
+     <property name="suffix">
+      <string> eV</string>
+     </property>
+     <property name="decimals">
+      <number>5</number>
+     </property>
+     <property name="minimum">
+      <double>-10000.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>10000.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0" colspan="2">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Energy step size:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>k points</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="2" colspan="2">
     <widget class="QDoubleSpinBox" name="spin_broadening">
      <property name="toolTip">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Gaussian broadening for Gaussian smoothing. The Gaussian broadening is the standard deviation.&lt;/p&gt;&lt;p&gt;Default: 0.1&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -159,87 +253,25 @@ p, li { white-space: pre-wrap; }
      </property>
     </widget>
    </item>
-   <item row="16" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="0" column="2" colspan="2">
+    <widget class="QSpinBox" name="spin_numValElectrons">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter the number of k-points that will be connecting the special k-points. More of these k-points will smooth out the graph, but the calculation may take longer.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="1">
-    <widget class="QDoubleSpinBox" name="spin_maxY">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="prefix">
-      <string>Max Y: </string>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
      </property>
      <property name="suffix">
-      <string> eV</string>
-     </property>
-     <property name="decimals">
-      <number>5</number>
+      <string/>
      </property>
      <property name="minimum">
-      <double>-10000.000000000000000</double>
+      <number>0</number>
      </property>
      <property name="maximum">
-      <double>10000.000000000000000</double>
+      <number>999999</number>
      </property>
-    </widget>
-   </item>
-   <item row="7" column="1">
-    <widget class="QCheckBox" name="cb_displayData">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Whether or not to display the density of states data in a&lt;/p&gt;&lt;p&gt;pop-up box after the calculation finishes.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Data may be copied and pasted into a separate file.&lt;/p&gt;&lt;p&gt;Default: off&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Display DOS data?</string>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="0">
-    <widget class="QDoubleSpinBox" name="spin_minY">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="prefix">
-      <string>Min Y: </string>
-     </property>
-     <property name="suffix">
-      <string> eV</string>
-     </property>
-     <property name="decimals">
-      <number>5</number>
-     </property>
-     <property name="minimum">
-      <double>-10000.000000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>10000.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <widget class="QCheckBox" name="cb_zeroFermi">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Subtracts the Fermi energy from all other energies so that the Fermi energy is set to be zero.&lt;/p&gt;&lt;p&gt;Default: off&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Zero the Fermi level?</string>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="1">
-    <widget class="QCheckBox" name="cb_limitY">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Limit the y-range?&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Default: off&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Limit y-range?</string>
+     <property name="value">
+      <number>1</number>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Major change:
Checkboxes have been added to the band structure calculation
dialog and the total density of states dialog so that the user
may specify the system to be 1-D or 2-D instead of 3-D. If the user
specifies a 1-D system, periodicity will only be along the A vector
of the unit cell. If the user specifies a 2-D system, periodicity
will be along the A and B vectors of the unit cell.

Other changes:
"size_t" changed to "int" in several places where Qt containers are used
in order to reduce the "signed compared to unsigned" warnings.

numvalenceelectrons.h now have all of its valence electrons set to
exactly match that of YAeHMOP. In addition, it only goes up to the
atomic number that YAeHMOP does (90).

getNumValAndKPoints() name changed to getUserOptions()
getKPointInfo() name changed to getUserOptions()

Plotting a dashed line is cleaned up for clarity

Trapezoidal integration is now correctly divided by 2 and
the normalization factor for smoothing is multiplied by 2 to
take this into account. The DOS still integrates to the correct
numbers of electrons.

getMolecule() functions added for future use to yaehmopextension.h

A few extra safety checks in yaehmopout.cpp