### PR TITLE
Added ability to show all atom images in a crystal

### DIFF
--- a/libavogadro/src/engine.cpp
+++ b/libavogadro/src/engine.cpp
@@ -196,6 +196,32 @@ namespace Avogadro {
     emit changed();
   }
 
+  void Engine::addAtomImage(Atom *a)
+  {
+    if (m_customPrims) {
+      if (!m_atomImages.contains(a))
+        m_atomImages.append(a);
+    }
+    else {
+      useCustomPrimitives();
+      if (!m_atomImages.contains(a))
+        m_atomImages.append(a);
+    }
+    emit changed();
+  }
+
+  void Engine::removeAtomImage(Atom *a)
+  {
+    if (m_customPrims) {
+      m_atomImages.removeAll(a);
+    }
+    else {
+      useCustomPrimitives();
+      m_atomImages.removeAll(a);
+    }
+    emit changed();
+  }
+
   void Engine::addBond(Bond *b)
   {
     if (m_customPrims) {
@@ -366,6 +392,14 @@ namespace Avogadro {
       return m_atoms;
     else
       return m_molecule->atoms();
+  }
+
+  const QList<Atom *> Engine::atomImages() const
+  {
+    if (m_customPrims)
+      return m_atomImages;
+    else
+      return QList<Atom *>();
   }
 
   const QList<Bond *> Engine::bonds() const

--- a/libavogadro/src/engine.h
+++ b/libavogadro/src/engine.h
@@ -323,6 +323,13 @@ namespace Avogadro {
       virtual const QList<Atom *> atoms() const;
 
       /**
+       * @return the engine's Atom images list containing all atoms the engine
+       * can render (but not to be selectable in the view). If m_customPrims
+       * is not on, it will return an empty list.
+       */
+      virtual const QList<Atom *> atomImages() const;
+
+      /**
        * @return the engine's Bond list containing all bonds the engine
        * can render.
        */
@@ -421,7 +428,7 @@ namespace Avogadro {
 
       /**
        * Signals that the engine has been enabled or disabled.
-       */ 
+       */
       void enableToggled(bool enabled);
 
     public Q_SLOTS:
@@ -454,6 +461,21 @@ namespace Avogadro {
        * @param atom to be removed from the atom list.
        */
       virtual void removeAtom(Atom *atom);
+
+      /**
+       * Add the Atom to the engine's atom images list. This atom will be
+       * drawn but will not be selectable in the GUI. It should be an Atom
+       * in a Molecule object stored somewhere (not the Molecule stored in
+       * this class).
+       * @param atom to be added to the atom images list.
+       */
+      virtual void addAtomImage(Atom *atom);
+
+      /**
+       * Remove the Atom from the engine's atom images list.
+       * @param atom to be removed from the atom images list.
+       */
+      virtual void removeAtomImage(Atom *atom);
 
       /**
        * Add the Bond to the engines bond list.
@@ -499,6 +521,7 @@ namespace Avogadro {
       bool m_customPrims;
       PrimitiveList m_primitives;
       QList<Atom *> m_atoms;
+      QList<Atom *> m_atomImages;
       QList<Bond *> m_bonds;
       QString m_alias;
       QString m_description;

--- a/libavogadro/src/engines/bsdyengine.cpp
+++ b/libavogadro/src/engines/bsdyengine.cpp
@@ -177,8 +177,9 @@ namespace Avogadro
     glDisable( GL_NORMALIZE );
     glEnable( GL_RESCALE_NORMAL );
 
-    // Render the atoms
-    foreach(const Atom *a, atoms()) {
+    // Render the atoms and atom images
+    QList<Atom *> allAtoms = atoms() + atomImages();
+    foreach(const Atom *a, allAtoms) {
       map->setFromPrimitive(a);
       if (a->customColorName().isEmpty())
         pd->painter()->setColor( map );
@@ -206,7 +207,10 @@ namespace Avogadro
 
     glDisable( GL_NORMALIZE );
     glEnable( GL_RESCALE_NORMAL );
-    foreach(const Atom *a, atoms()) {
+
+    // Render the atoms and atom images
+    QList<Atom *> allAtoms = atoms() + atomImages();
+    foreach(const Atom *a, allAtoms) {
       // First render the atom if it is transparent.
       if (m_alpha < 0.999 && m_alpha > 0.001) {
         if (a->customColorName().isEmpty()) {
@@ -329,8 +333,9 @@ namespace Avogadro
     glDisable(GL_NORMALIZE);
     glEnable(GL_RESCALE_NORMAL);
 
-    // Render the atoms
-    foreach(Atom *a, atoms()) {
+    // Render the atoms and atom images
+    QList<Atom *> allAtoms = atoms() + atomImages();
+    foreach(Atom *a, allAtoms) {
       if (pd->isSelected(a)) {
         pd->painter()->setColor(&cSel);
         pd->painter()->drawSphere(a->pos(), SEL_ATOM_EXTRA_RADIUS + radius(a));
@@ -358,7 +363,7 @@ namespace Avogadro
       pd->painter()->drawCylinder(*b->beginPos(), *b->endPos(), m_bondRadius+0.05);
     }
 
-    // Render the atoms
+    // Render the atoms (no atom images - they should not be selectable)
     foreach(Atom *a, atoms())  {
       pd->painter()->setName(a);
       // add a slight "slop" factor to make it easier to pick

--- a/libavogadro/src/engines/sphereengine.cpp
+++ b/libavogadro/src/engines/sphereengine.cpp
@@ -72,7 +72,8 @@ namespace Avogadro {
       // Render the atoms as VdW spheres
       glDisable(GL_NORMALIZE);
       glEnable(GL_RESCALE_NORMAL);
-      foreach(Atom *a, atoms())
+      QList<Atom *> allAtoms = atoms() + atomImages();
+      foreach(Atom *a, allAtoms)
         render(pd, a);
       glDisable(GL_RESCALE_NORMAL);
       glEnable(GL_NORMALIZE);
@@ -95,7 +96,10 @@ namespace Avogadro {
       // with a slightly smaller radius than the actual VdW spheres. Works but
       // not pretty...
       pd->painter()->setColor(0.0, 0.0, 0.0, 1.0);
-      foreach(Atom *a, atoms()) {
+
+      // Render all atoms and atom images
+      QList<Atom *> allAtoms = atoms() + atomImages();
+      foreach(Atom *a, allAtoms) {
         pd->painter()->drawSphere(a->pos(), radius(a)*0.9999);
       }
 
@@ -107,7 +111,7 @@ namespace Avogadro {
       glDisable(GL_NORMALIZE);
       glEnable(GL_RESCALE_NORMAL);
 
-      foreach(Atom *a, atoms())
+      foreach(Atom *a, allAtoms)
         render(pd, a);
 
       glDisable(GL_RESCALE_NORMAL);
@@ -137,6 +141,8 @@ namespace Avogadro {
     Color *map = colorMap();
     if (!map) map = pd->colorMap();
 
+    // We won't render atom images here because this is called by renderPick(),
+    // and we don't want the atom images to be selectable
     foreach(Atom *a, atoms()) {
       map->setFromPrimitive(a);
       pd->painter()->setColor(map);

--- a/libavogadro/src/engines/stickengine.cpp
+++ b/libavogadro/src/engines/stickengine.cpp
@@ -75,8 +75,9 @@ namespace Avogadro {
     glDisable( GL_NORMALIZE );
     glEnable( GL_RESCALE_NORMAL );
 
-    // Render the atoms
-    foreach(Atom *a, atoms())
+    // Render the atoms and images
+    QList<Atom *> allAtoms = atoms() + atomImages();
+    foreach(Atom *a, allAtoms)
       renderOpaque(pd, a);
 
     // render bonds (sticks)
@@ -100,8 +101,9 @@ namespace Avogadro {
     map->setToSelectionColor();
     pd->painter()->setColor(map);
 
-    // Render the atoms
-    foreach(Atom *a, atoms()) {
+    // Render the atoms and images
+    QList<Atom *> allAtoms = atoms() + atomImages();
+    foreach(Atom *a, allAtoms) {
       if (pd->isSelected(a)) {
         pd->painter()->setName(a);
         pd->painter()->drawSphere(a->pos(), SEL_ATOM_EXTRA_RADIUS + radius(a));
@@ -125,13 +127,13 @@ namespace Avogadro {
 
     return true;
   }
-  
+
   bool StickEngine::renderPick(PainterDevice *pd)
   {
     glDisable( GL_NORMALIZE );
     glEnable( GL_RESCALE_NORMAL );
 
-    // Render the atoms
+    // Render the atoms (no images)
     foreach(Atom *a, atoms())
       renderPick(pd, a);
 

--- a/libavogadro/src/extensions/crystallography/ui/ceviewoptionswidget.h
+++ b/libavogadro/src/extensions/crystallography/ui/ceviewoptionswidget.h
@@ -28,6 +28,7 @@ namespace Avogadro
 {
   class CrystallographyExtension;
   class GLWidget;
+  class Molecule;
 
   class CEViewOptionsWidget : public CEAbstractDockWidget
   {
@@ -38,6 +39,7 @@ namespace Avogadro
     ~CEViewOptionsWidget();
 
     GLWidget * glWidget() const {return m_glWidget;}
+    Molecule * molecule() const {return m_molecule;}
 
     enum NumCellChoice {
       NCC_Invalid = -1,
@@ -47,14 +49,21 @@ namespace Avogadro
     };
 
   public slots:
-    void setGLWidget(GLWidget *g) {m_glWidget = g;}
+    void setGLWidget(GLWidget *g);
+    void setMolecule(Molecule *m);
 
   protected slots:
+    void makeMoleculeConnections();
+    void disconnectMoleculeConnections();
     void updateRepeatCells();
     void updateCamera();
     void updateMillerPlane();
     void millerIndexChanged();
     void updateCellRenderOptions();
+    void setDisplayAllAtomImages(bool b);
+    void generateExtraAtomImages();
+    void removeExtraAtomImages();
+    void resetExtraAtomImages();
 
     // Color selection
     void selectCellColor();
@@ -74,10 +83,13 @@ namespace Avogadro
   protected:
     Ui::CEViewOptionsWidget ui;
     GLWidget *m_glWidget;
+    Molecule *m_molecule;
+    Molecule *m_extraImagesMolecule;
     Qt::DockWidgetArea m_currentArea;
     NumCellChoice m_ncc;
     QColorDialog *m_colorDialog;
     QColor *m_origColor;
+    bool m_displayAllAtomImages;
   };
 
 }

--- a/libavogadro/src/extensions/crystallography/ui/ceviewoptionswidget.ui
+++ b/libavogadro/src/extensions/crystallography/ui/ceviewoptionswidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>445</width>
-    <height>253</height>
+    <height>278</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -442,7 +442,7 @@
       </item>
      </layout>
     </item>
-    <item row="1" column="0">
+    <item row="2" column="0">
      <spacer name="verticalSpacer">
       <property name="orientation">
        <enum>Qt::Vertical</enum>
@@ -454,6 +454,16 @@
        </size>
       </property>
      </spacer>
+    </item>
+    <item row="1" column="0">
+     <widget class="QCheckBox" name="cb_displayAllAtomImages">
+      <property name="toolTip">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If an atom is on a face, edge, or vertex, its image will also be shown on the other corresponding faces, edges, or vertices.&lt;/p&gt;&lt;p&gt;For example, if an atom is on one AB face, and this box is checked, the atom's image will be displayed on the opposite AB face as well.&lt;/p&gt;&lt;p&gt;The atom must be very close to the edge, face, or vertex in order for this to take effect.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="text">
+       <string>Display all atom images?</string>
+      </property>
+     </widget>
     </item>
    </layout>
   </widget>


### PR DESCRIPTION
Added a checkbox to the crystal view options menu
(view->crystal view options...) that allows the user
to display all atom images in a crystal. It does so
by adding atoms to each engine that dislays atoms in
the needed positions.

If an atom is in a corner, images of that atom will be
placed in all the other corners.

If an atom is on an edge, images of that atom will be
placed on the other three edges it is shared with.

If an atom is on a face, images of that atom will be
placed on the opposite face.

The images are not considered to be separate atom

This method appears to be robust and work fine when dealing
with crystal dialogs. Unfortunately, if a user uses tools such
as the drawing tool or manipulate tool on the images, the program
can behave strangely and crash.