### PR TITLE
cppcheck: fix logical issues

### DIFF
--- a/libavogadro/src/extensions/quantuminput/gamessinputdata.cpp
+++ b/libavogadro/src/extensions/quantuminput/gamessinputdata.cpp
@@ -408,7 +408,7 @@ void GamessControlGroup::InitProgPaneData( void )
 }
 GAMESS_SCFType GamessControlGroup::SetSCFType( GAMESS_SCFType NewSCFType )
 {
-  if (( NewSCFType >= GAMESSDefaultSCFType )||( NewSCFType<NumGAMESSSCFTypes ) )
+  if (( NewSCFType >= GAMESSDefaultSCFType )&&( NewSCFType<NumGAMESSSCFTypes ) )
     SCFType = NewSCFType;
   return SCFType;
 }
@@ -1398,7 +1398,7 @@ short GamessBasisGroup::SetDiffuseS( bool state )
 }
 GAMESS_BS_Polarization GamessBasisGroup::SetPolar( GAMESS_BS_Polarization NewPolar )
 {
-  if (( NewPolar>=GAMESS_BS_No_Polarization )||( NewPolar<NumGAMESSBSPolarItems ) ) {
+  if (( NewPolar>=GAMESS_BS_No_Polarization )&&( NewPolar<NumGAMESSBSPolarItems ) ) {
     Polar = NewPolar;
   }
   return Polar;
@@ -1712,7 +1712,7 @@ CoordinateType GamessDataGroup::SetCoordType( const char * CoordText )
 }
 CoordinateType GamessDataGroup::SetCoordType( CoordinateType NewType )
 {
-  if (( NewType<UniqueCoordType )&&( NewType>NumberCoordinateTypes ) ) return invalidCoordinateType;
+  if (( NewType<UniqueCoordType )||( NewType>NumberCoordinateTypes ) ) return invalidCoordinateType;
   Coord = NewType;
   return ( CoordinateType ) Coord;
 }


### PR DESCRIPTION
[libavogadro/src/extensions/quantuminput/gamessinputdata.cpp:411]: (warning) Logical disjunction always evaluates to true: NewSCFType >= 0 || NewSCFType < 7.
[libavogadro/src/extensions/quantuminput/gamessinputdata.cpp:1401]: (warning) Logical disjunction always evaluates to true: NewPolar >= 0 || NewPolar < 6.
[libavogadro/src/extensions/quantuminput/gamessinputdata.cpp:1715]: (warning) Logical conjunction always evaluates to false: NewType < 1 && NewType > 6.

I know quantuminput is an extension but didn't find (or missed) upstream lib.