### PR TITLE
Adapted Python `Animation` class to changes introduced in commit fe33cedaabb2bec5b06f022a83083cd0e0df4012

### DIFF
--- a/libavogadro/src/python/animation.cpp
+++ b/libavogadro/src/python/animation.cpp
@@ -20,8 +20,8 @@ void export_Animation()
         "molecule topology before the trajectory. The trajectory frames can "
         "be used to call setFrames() later.") // @todo unit test conversion for argument
     .add_property("fps", &Animation::fps, &Animation::setFps, "The number of frames per second.")
-    .add_property("loopCount", &Animation::loopCount, &Animation::setLoopCount, 
-        "The number of loops (0 = repeat forever).")
+    .add_property("loop", &Animation::loop, &Animation::setLoop,
+        "Whether to loop the animation.")
     .add_property("numFrames", &Animation::numFrames, "The total number of frames in the animation.")
     .add_property("dynamicBonds", &Animation::dynamicBonds, &Animation::setDynamicBonds, 
         "True if dynamic bond detection is enabled.")


### PR DESCRIPTION
In commit fe33cedaabb2bec5b06f022a83083cd0e0df4012 (pull request #859, merged in commit 0ff6c20050305f28a451e1a3f0ef981c7200edfd), I changed the `animation` module. Unfortunately, I did not try to build the associated Python module before creating my pull request, so that I only now realized that the changes I had made there required adapting the Python `Animation` class. This commit is intended to amend that oversight.

This commit is released to the public domain.