### PR TITLE
Fixed linker error when building Python module by linking to OpenBabel.

### DIFF
--- a/libavogadro/src/python/CMakeLists.txt
+++ b/libavogadro/src/python/CMakeLists.txt
@@ -21,7 +21,7 @@ if (WIN32)
   target_link_libraries(python-module avogadro ${PYTHON_LIBRARIES})
 else()
   target_link_libraries(python-module stdc++ avogadro
-    ${QT_LIBRARIES} ${PYTHON_LIBRARIES} ${Boost_LIBRARIES})
+    ${QT_LIBRARIES} ${PYTHON_LIBRARIES} ${Boost_LIBRARIES} ${OPENBABEL2_LIBRARIES})
 endif()
 
 # Let's try to use this instead:


### PR DESCRIPTION
When building the Python module, the linker fails in the following way:

CMakeFiles/python-module.dir/swig.cpp.o: In function `Molecule_OBMol(Avogadro::Molecule&)':
libavogadro/src/python/swig.cpp:554: undefined reference to `OpenBabel::OBMol::OBMol(OpenBabel::OBMol const&)'
libavogadro/src/python/swig.cpp:554: undefined reference to `OpenBabel::OBMol::~OBMol()'
libavogadro/src/python/swig.cpp:554: undefined reference to `OpenBabel::OBMol::~OBMol()'
collect2: error: ld returned 1 exit status
libavogadro/src/python/CMakeFiles/python-module.dir/build.make:990: recipe for target 'lib/Avogadro.so' failed

(Note that, in order to get to the linker stage in the first place, one may need to treat the compilation error described and fixed in pull request #871, commit 776cb94dd11d849a7e8a531ad05741060a710b3c.)

Adding `${OPENBABEL2_LIBRARIES}` to the list of libraries to link into the Python module fixes this issue, at least for my non-`WIN32` platform. For the latter, it may be necessary to adapt line 21 in `libavogadro/src/python/CMakeLists.txt` accordingly, but unfortunately, I cannot try this myself.

This commit is released to the public domain.