### PR TITLE
Fixed CMake syntax error

### DIFF
--- a/libavogadro/src/extensions/yaehmop/CMakeLists.txt
+++ b/libavogadro/src/extensions/yaehmop/CMakeLists.txt
@@ -73,4 +73,4 @@ if(NOT ${USE_SYSTEM_YAEHMOP} AND
                       GROUP_READ GROUP_EXECUTE
                       WORLD_READ WORLD_EXECUTE)
 
-endif(NOT EXISTS ${CMAKE_BINARY_DIR}/bin/${YAEHMOP_NAME})
+endif()


### PR DESCRIPTION
Arguments didn't match, old style so just convert to new style.