### PR TITLE
Fix spg change tolerance bug

### DIFF
--- a/libavogadro/src/extensions/crystallography/crystallographyextension.cpp
+++ b/libavogadro/src/extensions/crystallography/crystallographyextension.cpp
@@ -2440,6 +2440,7 @@ namespace Avogadro
            QMessageBox::Yes | QMessageBox::No,
            QMessageBox::Yes)
           == QMessageBox::Yes) {
+        actionSpgTolerance();
         return actionPerceiveSpacegroup();
       }
       else {
@@ -2614,6 +2615,7 @@ namespace Avogadro
            QMessageBox::Yes | QMessageBox::No,
            QMessageBox::Yes)
           == QMessageBox::Yes) {
+        actionSpgTolerance();
         return actionSymmetrizeCrystal();
       }
       else {
@@ -2629,6 +2631,7 @@ namespace Avogadro
            QMessageBox::Yes | QMessageBox::No,
            QMessageBox::Yes)
           == QMessageBox::Yes) {
+        actionSpgTolerance();
         return actionSymmetrizeCrystal();
       }
       else {
@@ -2796,7 +2799,8 @@ namespace Avogadro
            QMessageBox::Yes | QMessageBox::No,
            QMessageBox::Yes)
           == QMessageBox::Yes) {
-        return actionPrimitiveReduce();
+        actionSpgTolerance();
+        return actionPrimitiveReduceStandard();
       }
       else {
         return;


### PR DESCRIPTION
When a user tries to perform spglib operations and
they fail (because the tolerance is too small), a dialog
box will appear and say "Would you like to try again with a
different tolerance"? If you say "yes", nothing happens.

This fixes that bug so that when the user says "yes", it asks
for a new tolerance, and then re-runs the operation.