### PR TITLE
Configurable box padding for orbital cubes

### DIFF
--- a/libavogadro/src/extensions/surfaces/orbitalextension.cpp
+++ b/libavogadro/src/extensions/surfaces/orbitalextension.cpp
@@ -396,7 +396,7 @@ namespace Avogadro
   void OrbitalExtension::calculateOrbitalFromWidget(unsigned int orbital,
                                                     double resolution)
   {
-    addCalculationToQueue(orbital, resolution, m_widget->isovalue(), 0);
+    addCalculationToQueue(orbital, resolution, m_widget->isovalue(), m_widget->boxPadding(), 0);
     checkQueue();
   }
 
@@ -437,6 +437,7 @@ namespace Avogadro
         addCalculationToQueue(i+1,  // orbital
                               OrbitalWidget::OrbitalQualityToDouble(m_widget->defaultQuality()),
                               m_widget->isovalue(),
+                              m_widget->boxPadding(),
                               priority);
 
         // Update priority. Stays the same when i = homo.
@@ -450,6 +451,7 @@ namespace Avogadro
   void OrbitalExtension::addCalculationToQueue(unsigned int orbital,
                                                double resolution,
                                                double isovalue,
+                                               double boxPadding,
                                                unsigned int priority)
   {
     // Create new queue entry
@@ -457,6 +459,7 @@ namespace Avogadro
     newCalc.orbital = orbital;
     newCalc.resolution = resolution;
     newCalc.isovalue = isovalue;
+    newCalc.boxPadding = boxPadding;
     newCalc.priority = priority;
     newCalc.state = NotStarted;
 
@@ -506,7 +509,8 @@ namespace Avogadro
       calcInfo *cI = &m_queue[i];
       if (cI->state == Completed &&
           cI->orbital == info->orbital &&
-          cI->resolution == info->resolution) {
+          cI->resolution == info->resolution &&
+          cI->boxPadding == info->boxPadding) {
         info->cube = cI->cube;
         qDebug() << "Reusing cube from calculation " << i << ":\n"
                  << "\tOrbital " << cI->orbital << "\n"
@@ -519,7 +523,7 @@ namespace Avogadro
     // Create new cube
     Cube *cube = m_molecule->addCube();
     info->cube = cube;
-    cube->setLimits(m_molecule, info->resolution, 2.5);
+    cube->setLimits(m_molecule, info->resolution, info->boxPadding);
 
     if (m_qube) {
       delete m_qube;
@@ -575,12 +579,14 @@ namespace Avogadro
       if (cI->state == Completed &&
           cI->orbital == info->orbital &&
           cI->resolution == info->resolution &&
-          cI->isovalue == info->isovalue) {
+          cI->isovalue == info->isovalue &&
+          cI->boxPadding == info->boxPadding) {
         info->posMesh = cI->posMesh;
         qDebug() << "Reusing posMesh from calculation " << i << ":\n"
                  << "\tOrbital " << cI->orbital << "\n"
                  << "\tResolution " << cI->resolution << "\n"
-                 << "\tIsovalue " << cI->isovalue;
+                 << "\tIsovalue " << cI->isovalue << "\n"
+                 << "\tBoxpadding " << cI->boxPadding;
         m_widget->nextProgressStage(info->orbital, 0, 100);
         calculateNegMesh();
         return;
@@ -642,12 +648,14 @@ namespace Avogadro
       if (cI->state == Completed &&
           cI->orbital == info->orbital &&
           cI->resolution == info->resolution &&
-          cI->isovalue == info->isovalue) {
+          cI->isovalue == info->isovalue &&
+          cI->boxPadding == info->boxPadding) {
         info->negMesh = cI->negMesh;
-        qDebug() << "Reusing posMesh from calculation " << i << ":\n"
+        qDebug() << "Reusing negMesh from calculation " << i << ":\n"
                  << "\tOrbital " << cI->orbital << "\n"
                  << "\tResolution " << cI->resolution << "\n"
-                 << "\tIsovalue " << cI->isovalue;
+                 << "\tIsovalue " << cI->isovalue << "\n"
+                 << "\tBoxpadding " << cI->boxPadding;
         m_widget->nextProgressStage(info->orbital, 0, 100);
         calculationComplete();
         return;

--- a/libavogadro/src/extensions/surfaces/orbitalextension.h
+++ b/libavogadro/src/extensions/surfaces/orbitalextension.h
@@ -65,6 +65,7 @@ namespace Avogadro
     unsigned int orbital;
     double resolution;
     double isovalue;
+    double boxPadding;
     unsigned int priority;
     CalcState state;
   };
@@ -129,11 +130,13 @@ namespace Avogadro
      * @param orbital Orbital number
      * @param resolution Resolution of grid
      * @param isoval Isovalue for surface
+     * @param boxPadding Box padding for orbital render cube
      * @param priority Priority. Default = 0 (user requested)
      */
     void addCalculationToQueue(unsigned int orbital,
                                double resolution,
                                double isoval,
+                               double boxPadding,
                                unsigned int priority = 0);
     /**
      * Check that no calculations are currently running and start the

--- a/libavogadro/src/extensions/surfaces/orbitalsettingsdialog.cpp
+++ b/libavogadro/src/extensions/surfaces/orbitalsettingsdialog.cpp
@@ -33,6 +33,7 @@ namespace Avogadro {
     : QDialog(parent, f),
       m_quality(OrbitalWidget::OQ_Low),
       m_isoval(0.02),
+      m_boxPadding(2.5),
       m_HOMOFirst(false),
       m_limit_precalc(true),
       m_precalc_range(10)
@@ -44,8 +45,8 @@ namespace Avogadro {
 
     connect(this, SIGNAL(calculateAll()),
             parent, SIGNAL(calculateAll()));
-    connect(this, SIGNAL(defaultsUpdated(OrbitalWidget::OrbitalQuality, double, bool)),
-            parent, SLOT(setDefaults(OrbitalWidget::OrbitalQuality, double, bool)));
+    connect(this, SIGNAL(defaultsUpdated(OrbitalWidget::OrbitalQuality, double, double, bool)),
+            parent, SLOT(setDefaults(OrbitalWidget::OrbitalQuality, double, double, bool)));
     connect(this, SIGNAL(precalcSettingsUpdated(bool,int)),
             parent, SLOT(setPrecalcSettings(bool,int)));
   }
@@ -64,6 +65,12 @@ namespace Avogadro {
   {
     ui.spin_isoval->setValue(i);
     m_isoval = i;
+  }
+
+  void OrbitalSettingsDialog::setBoxPadding(double i)
+  {
+    ui.spin_boxPadding->setValue(i);
+    m_boxPadding = i;
   }
 
   void OrbitalSettingsDialog::setHOMOFirst(bool HOMOFirst)
@@ -88,8 +95,9 @@ namespace Avogadro {
   {
     m_quality = OrbitalWidget::OrbitalQuality(ui.combo_quality->currentIndex());
     m_isoval = ui.spin_isoval->value();
+    m_boxPadding = ui.spin_boxPadding->value();
     m_HOMOFirst = ui.cb_HOMOFirst->isChecked();
-    emit defaultsUpdated(m_quality, m_isoval, m_HOMOFirst);
+    emit defaultsUpdated(m_quality, m_isoval, m_boxPadding, m_HOMOFirst);
   }
 
   void OrbitalSettingsDialog::updatePrecalcSettings()
@@ -110,6 +118,7 @@ namespace Avogadro {
   {
     setDefaultQuality(m_quality);
     setIsoValue(m_isoval);
+    setBoxPadding(m_boxPadding);
     setHOMOFirst(m_HOMOFirst);
     hide();
   }

--- a/libavogadro/src/extensions/surfaces/orbitalsettingsdialog.h
+++ b/libavogadro/src/extensions/surfaces/orbitalsettingsdialog.h
@@ -44,6 +44,7 @@ namespace Avogadro
   public slots:
     void setDefaultQuality(OrbitalWidget::OrbitalQuality);
     void setIsoValue(double);
+    void setBoxPadding(double);
     void setHOMOFirst(bool);
     void setLimitPrecalc(bool);
     void setPrecalcRange(int);
@@ -55,7 +56,7 @@ namespace Avogadro
   signals:
     void calculateAll();
     void defaultsUpdated(OrbitalWidget::OrbitalQuality quality, double isoval,
-                         bool HOMOFirst);
+                         double boxPadding, bool HOMOFirst);
     void precalcSettingsUpdated(bool limit, int range);
 
   private slots:
@@ -65,6 +66,7 @@ namespace Avogadro
     Ui::OrbitalSettingsDialog ui;
     OrbitalWidget::OrbitalQuality m_quality;
     double m_isoval;
+    double m_boxPadding;
     bool m_HOMOFirst;
     bool m_limit_precalc;
     int m_precalc_range;

--- a/libavogadro/src/extensions/surfaces/orbitalsettingsdialog.ui
+++ b/libavogadro/src/extensions/surfaces/orbitalsettingsdialog.ui
@@ -14,7 +14,7 @@
    <string>Dialog</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="6" column="0">
+   <item row="7" column="0">
     <widget class="QPushButton" name="push_recalc">
      <property name="text">
       <string>&amp;Recalculate All</string>
@@ -38,6 +38,16 @@
      </property>
      <property name="buddy">
       <cstring>spin_isoval</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>&amp;Box Padding:</string>
+     </property>
+     <property name="buddy">
+      <cstring>spin_boxPadding</cstring>
      </property>
     </widget>
    </item>
@@ -75,7 +85,17 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="2" column="1">
+    <widget class="QDoubleSpinBox" name="spin_boxPadding">
+     <property name="decimals">
+      <number>1</number>
+     </property>
+     <property name="singleStep">
+      <double>0.1</double>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -88,14 +108,14 @@
      </property>
     </spacer>
    </item>
-   <item row="2" column="0" colspan="2">
+   <item row="3" column="0" colspan="2">
     <widget class="QCheckBox" name="cb_HOMOFirst">
      <property name="text">
       <string>Show occupied orbitals first</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="7" column="1">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -105,7 +125,7 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0" colspan="2">
+   <item row="4" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QCheckBox" name="cb_limit_precalc">

--- a/libavogadro/src/extensions/surfaces/orbitalwidget.cpp
+++ b/libavogadro/src/extensions/surfaces/orbitalwidget.cpp
@@ -30,6 +30,7 @@ namespace Avogadro {
     m_settings(0),
     m_quality(OQ_Low),
     m_isovalue(0.02),
+    m_boxPadding(2.5),
     m_precalc_limit(true),
     m_precalc_range(10),
     m_tableModel(new OrbitalTableModel (this)),
@@ -64,6 +65,7 @@ namespace Avogadro {
     settings.beginGroup("orbitals");
     m_quality = OrbitalQuality(        settings.value("defaultQuality", 0).toInt());
     m_isovalue =                       settings.value("isoValue", 0.02).toDouble();
+    m_boxPadding =                     settings.value("boxPadding", 2.5).toDouble();
     ui.combo_quality->setCurrentIndex( settings.value("selectedQuality", 0).toInt());
     m_sortedTableModel->HOMOFirst(     settings.value("HOMOFirst", false).toBool());
     m_precalc_limit =                  settings.value("precalc/limit", true).toBool();
@@ -77,6 +79,7 @@ namespace Avogadro {
     settings.beginGroup("orbitals");
     settings.setValue("defaultQuality", m_quality);
     settings.setValue("isoValue", m_isovalue);
+    settings.setValue("boxPadding", m_boxPadding);
     settings.setValue("selectedQuality", ui.combo_quality->currentIndex());
     settings.setValue("HOMOFirst", m_sortedTableModel->isHOMOFirst());
     settings.setValue("precalc/limit", m_precalc_limit);
@@ -96,6 +99,7 @@ namespace Avogadro {
     }
     m_settings->setDefaultQuality(m_quality);
     m_settings->setIsoValue(m_isovalue);
+    m_settings->setBoxPadding(m_boxPadding);
     m_settings->setHOMOFirst(m_sortedTableModel->isHOMOFirst());
     m_settings->setLimitPrecalc(m_precalc_limit);
     m_settings->setPrecalcRange(m_precalc_range);
@@ -195,10 +199,11 @@ namespace Avogadro {
     }
   }
 
-  void OrbitalWidget::setDefaults(OrbitalQuality q, double i, bool HOMOFirst)
+  void OrbitalWidget::setDefaults(OrbitalQuality q, double i, double bp, bool HOMOFirst)
   {
     m_quality = q;
     m_isovalue = i;
+    m_boxPadding = bp;
     m_sortedTableModel->HOMOFirst(HOMOFirst);
     m_sortedTableModel->sort(0, Qt::AscendingOrder);
   }

--- a/libavogadro/src/extensions/surfaces/orbitalwidget.h
+++ b/libavogadro/src/extensions/surfaces/orbitalwidget.h
@@ -52,6 +52,7 @@ namespace Avogadro {
       virtual ~OrbitalWidget();
 
       double isovalue() {return m_isovalue;};
+      double boxPadding() {return m_boxPadding;};
       OrbitalQuality defaultQuality() {return m_quality;};
 
       bool precalcLimit() {return m_precalc_limit;}
@@ -68,7 +69,7 @@ namespace Avogadro {
       void fillTable(QList<Orbital> list);
       void setQuality(OrbitalQuality q);
       void selectOrbital(unsigned int orbital);
-      void setDefaults(OrbitalWidget::OrbitalQuality quality, double isovalue, bool HOMOFirst);
+      void setDefaults(OrbitalWidget::OrbitalQuality quality, double isovalue, double boxPadding, bool HOMOFirst);
       void setPrecalcSettings(bool limit, int range);
       void initializeProgress(int orbital, int min, int max, int stage, int totalStages);
       void nextProgressStage(int orbital, int newmin, int newmax);
@@ -91,6 +92,7 @@ namespace Avogadro {
       OrbitalSettingsDialog *m_settings;
       OrbitalQuality m_quality;
       double m_isovalue;
+      double m_boxPadding;
 
       bool m_precalc_limit;
       int m_precalc_range;


### PR DESCRIPTION
This patch adds a new "boxPadding" option to molecular orbital visualisation.
It allows changing the amount of padding added to the orbital render cube (defaults to old value of 2.5).
By increasing it to a larger value you can see full orbitals that are otherwise cut off.

Very useful for observing large / diffuse Rydberg states